### PR TITLE
feat(hooks): main / dev への直接コミットを pre-commit でブロック

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,12 @@ output:
 pre-commit:
   parallel: true
   commands:
+    main-branch-guard:
+      run: bash scripts/hooks/main-branch-guard.sh
+      stage_fixed: false
+      fail_text: |
+        🚫 main / dev ブランチへの直接コミットは禁止されています。
+        feature ブランチに切り替えてから commit してください。
     staged-task-dir-guard:
       run: bash scripts/hooks/staged-task-dir-guard.sh
       stage_fixed: false

--- a/scripts/hooks/main-branch-guard.sh
+++ b/scripts/hooks/main-branch-guard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# main / dev ブランチへの直接コミットを pre-commit で禁止する。
+# 解除する場合: ALLOW_DIRECT_COMMIT=1 git commit ...  または  git commit --no-verify
+set -euo pipefail
+
+if [[ "${ALLOW_DIRECT_COMMIT:-0}" == "1" ]]; then
+  exit 0
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+
+case "$current_branch" in
+  main|dev)
+    cat >&2 <<EOF
+🚫 '$current_branch' ブランチへの直接コミットは禁止されています。
+
+ブランチ戦略: feature/* --PR--> dev --PR--> main
+
+対処:
+  1) 別ブランチに切り替え:    git switch -c feat/<name>
+  2) ワークツリーで作業:      bash scripts/new-worktree.sh feat/<name>
+  3) どうしても必要な場合:    ALLOW_DIRECT_COMMIT=1 git commit ...
+                              または git commit --no-verify
+EOF
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary
- `scripts/hooks/main-branch-guard.sh` を追加し、`main` / `dev` ブランチでの `git commit` を pre-commit で拒否する
- `lefthook.yml` の pre-commit に `main-branch-guard` を組み込み（`staged-task-dir-guard` と並列実行）
- 意図的に直コミットしたい場合は `ALLOW_DIRECT_COMMIT=1` 環境変数 もしくは `git commit --no-verify` で解除可能

## Why
本セッション中、`main` ブランチに想定外のステージ済み変更や unmerged index 残骸が複数回出現し、
そのたびに rescue branch 化 → 安全削除 → fast-forward 復旧という重コストの清掃作業が必要になった。
ブランチ戦略 `feature/* → dev → main` を hook レベルで強制することで、誤って main / dev に
コミットしてしまう運用ミスを物理的に防止する。

## Test plan
- [x] `mise exec -- pnpm typecheck` 通過
- [x] `mise exec -- pnpm lint` 通過
- [x] feature ブランチ（本PR）での `git commit` が pre-commit を通過することを確認
- [x] main worktree から `bash scripts/hooks/main-branch-guard.sh` 実行で exit 1 + ガイダンス表示を確認
- [ ] マージ後、main で `git commit --allow-empty` を試みて拒否されることをスモークテスト
- [ ] `ALLOW_DIRECT_COMMIT=1 git commit --allow-empty` で解除できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)