### PR TITLE
docs(workflows): add 20 application-implementation follow-up task specs

### DIFF
--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/artifacts.json
@@ -1,0 +1,93 @@
+{
+  "task": "05b-A-auth-mail-env-contract-alignment",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "docsOnly": true,
+  "remainingOnly": true,
+  "depends_on": [],
+  "blocks": [
+    "05b-B-magic-link-callback-credentials-provider",
+    "09a-A-staging-deploy-smoke-execution",
+    "09c-A-production-deploy-execution"
+  ],
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/index.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/index.md
@@ -1,0 +1,109 @@
+# 05b-A-auth-mail-env-contract-alignment
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 05b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+Magic Link/認証メールの環境変数名と正本仕様の不整合を解消する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、プロトタイプ・仕様書・現行ソースを突き合わせて確認した未反映箇所だけを扱う。
+
+`docs/00-getting-started-manual/specs/10-notification-auth.md` と `08-free-database.md` は `RESEND_API_KEY` / `RESEND_FROM_EMAIL` / `SITE_URL` を要求する。一方、現行実装と aiworkflow-requirements は `MAIL_PROVIDER_KEY` / `MAIL_FROM_ADDRESS` / `AUTH_URL` を使う。このままだと Cloudflare Secrets 登録・runbook・実装のどれを正とするかが曖昧になり、staging/prod で Magic Link が失敗する可能性がある。
+
+## scope in / out
+
+### Scope In
+- 正本 env 名の決定
+- 実装または仕様書の片寄せ
+- 後方互換 alias の必要性判断
+- Cloudflare Secrets / 1Password / docs の同期
+- Magic Link send smoke の AC 更新
+
+### Scope Out
+- メール provider の全面変更
+- secret 実値の記録
+- 通知基盤 UT-07 全実装
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 05b Magic Link provider
+- 10-notification-auth.md
+- environment-variables.md
+- deployment-secrets-management.md
+
+### Blocks
+- 05b-B-magic-link-callback-credentials-provider
+- 09a-A-staging-deploy-smoke-execution（staging auth smoke）
+- 09c-A-production-deploy-execution（production deploy readiness）
+
+## refs
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## AC
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-01/main.md
@@ -1,0 +1,17 @@
+# Output Phase 1: 要件定義
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-02/main.md
@@ -1,0 +1,17 @@
+# Output Phase 2: 設計
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-03/main.md
@@ -1,0 +1,17 @@
+# Output Phase 3: 設計レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-04/main.md
@@ -1,0 +1,17 @@
+# Output Phase 4: テスト戦略
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-05/main.md
@@ -1,0 +1,17 @@
+# Output Phase 5: 実装ランブック
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-06/main.md
@@ -1,0 +1,17 @@
+# Output Phase 6: 異常系検証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-07/main.md
@@ -1,0 +1,17 @@
+# Output Phase 7: AC マトリクス
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-08/main.md
@@ -1,0 +1,17 @@
+# Output Phase 8: DRY 化
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-09/main.md
@@ -1,0 +1,17 @@
+# Output Phase 9: 品質保証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-10/main.md
@@ -1,0 +1,17 @@
+# Output Phase 10: 最終レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-11/main.md
@@ -1,0 +1,17 @@
+# Output Phase 11: 手動 smoke / 実測 evidence
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-12/main.md
@@ -1,0 +1,17 @@
+# Output Phase 12: ドキュメント更新
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/outputs/phase-13/main.md
@@ -1,0 +1,17 @@
+# Output Phase 13: PR 作成
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-01.md
@@ -1,0 +1,81 @@
+# Phase 1: 要件定義 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 1 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-02.md
@@ -1,0 +1,81 @@
+# Phase 2: 設計 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 2 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+最小責務で実装・運用設計を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-03.md
@@ -1,0 +1,81 @@
+# Phase 3: 設計レビュー — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 3 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューする。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-04.md
@@ -1,0 +1,81 @@
+# Phase 4: テスト戦略 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 4 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+自動・手動・外部環境検証の境界を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-05.md
@@ -1,0 +1,81 @@
+# Phase 5: 実装ランブック — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 5 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実装または運用実行時の手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-06.md
@@ -1,0 +1,81 @@
+# Phase 6: 異常系検証 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 6 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+失敗時、未設定時、権限不足時の挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-07.md
@@ -1,0 +1,81 @@
+# Phase 7: AC マトリクス — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 7 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+受入条件と evidence path を一対一に対応付ける。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-08.md
@@ -1,0 +1,81 @@
+# Phase 8: DRY 化 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 8 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+重複手順、重複設定、重複責務を削減する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-09.md
@@ -1,0 +1,81 @@
+# Phase 9: 品質保証 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 9 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+型、lint、test、security、observability の品質 gate を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-10.md
@@ -1,0 +1,81 @@
+# Phase 10: 最終レビュー — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 10 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実行前の最終判断材料を揃える。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-11.md
@@ -1,0 +1,81 @@
+# Phase 11: 手動 smoke / 実測 evidence — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 11 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+人手または外部環境でしか確認できない証跡を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-12.md
@@ -1,0 +1,81 @@
+# Phase 12: ドキュメント更新 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 12 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/phase-13.md
@@ -1,0 +1,81 @@
+# Phase 13: PR 作成 — 05b-A-auth-mail-env-contract-alignment
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-A-auth-mail-env-contract-alignment |
+| phase | 13 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+ユーザー承認後のPR作成条件だけを定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/10-notification-auth.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- .claude/skills/aiworkflow-requirements/references/environment-variables.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+- apps/api/src/index.ts
+- apps/api/src/routes/auth/index.ts
+- apps/api/src/services/mail/magic-link-mailer.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-A-auth-mail-env-contract-alignment/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link provider, 10-notification-auth.md, environment-variables.md, deployment-secrets-management.md
+- 下流: 05b Magic Link callback follow-up, 09a staging auth smoke, 09c production deploy readiness
+
+## 多角的チェック観点
+
+- #16 secret values never documented
+- #15 Auth session boundary
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- env 名の正本が1つに統一される
+- Cloudflare/1Password/runbook の配置先が一致する
+- production で未設定時 fail-closed の仕様が明記される
+- staging smoke で Magic Link メール送信設定を確認できる
+- secret 実値が repo/evidence に残らない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/artifacts.json
@@ -1,0 +1,95 @@
+{
+  "task": "05b-B-magic-link-callback-credentials-provider",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "docsOnly": true,
+  "remainingOnly": true,
+  "depends_on": [
+    "05b-A-auth-mail-env-contract-alignment"
+  ],
+  "blocks": [
+    "06b-C-profile-logged-in-visual-evidence",
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution"
+  ],
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/index.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/index.md
@@ -1,0 +1,106 @@
+# 05b-B-magic-link-callback-credentials-provider
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 05b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+Magic Link メール内 URL と Auth.js session 確立の接続漏れを実装する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、現状コード・正本仕様・未割当タスクを照合して残った未実装または未運用 gate だけを扱う。
+
+05b 本体は Magic Link 発行・検証 API と proxy を実装済みだが、API が発行する `/api/auth/callback/email?token=&email=` に対応する Web route と Auth.js Credentials Provider 本体が未実装である。これは証跡不足ではなく、ログイン導線が 404 または session 未確立になる実装漏れである。
+
+## scope in / out
+
+### Scope In
+- Auth.js Credentials Provider の本実装
+- `/api/auth/callback/email` GET route 実装
+- Magic Link verify 結果から JWT session 確立
+- 失敗時 redirect/error handling
+- unit/route contract test
+
+### Scope Out
+- Google OAuth 実装の置換
+- メール送信 provider 変更
+- production secret 値の記録
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 05b-A-auth-mail-env-contract-alignment（auth mail env 正本確定）
+- 05b Magic Link 発行・検証 API
+- 06b member login UI
+- AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+
+### Blocks
+- 06b-C-profile-logged-in-visual-evidence
+- 08b-A-playwright-e2e-full-execution（auth E2E full execution）
+- 09a-A-staging-deploy-smoke-execution（staging auth smoke）
+
+## refs
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## AC
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-01/main.md
@@ -1,0 +1,17 @@
+# Output Phase 1: 要件定義
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-02/main.md
@@ -1,0 +1,17 @@
+# Output Phase 2: 設計
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-03/main.md
@@ -1,0 +1,17 @@
+# Output Phase 3: 設計レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-04/main.md
@@ -1,0 +1,17 @@
+# Output Phase 4: テスト戦略
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-05/main.md
@@ -1,0 +1,17 @@
+# Output Phase 5: 実装ランブック
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-06/main.md
@@ -1,0 +1,17 @@
+# Output Phase 6: 異常系検証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-07/main.md
@@ -1,0 +1,17 @@
+# Output Phase 7: AC マトリクス
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-08/main.md
@@ -1,0 +1,17 @@
+# Output Phase 8: DRY 化
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-09/main.md
@@ -1,0 +1,17 @@
+# Output Phase 9: 品質保証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-10/main.md
@@ -1,0 +1,17 @@
+# Output Phase 10: 最終レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-11/main.md
@@ -1,0 +1,17 @@
+# Output Phase 11: 手動 smoke / 実測 evidence
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-12/main.md
@@ -1,0 +1,17 @@
+# Output Phase 12: ドキュメント更新
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/outputs/phase-13/main.md
@@ -1,0 +1,17 @@
+# Output Phase 13: PR 作成
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 1 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 2 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+最小責務で実装・運用設計を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 3 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 4 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+自動・手動・外部環境検証の境界を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 5 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実装または運用実行時の手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 6 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+失敗時、未設定時、権限不足時の挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 7 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+受入条件と evidence path を一対一に対応付ける。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 8 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+重複手順、重複設定、重複責務を削減する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 9 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+型、lint、test、security、observability の品質 gate を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 10 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実行前の最終判断材料を揃える。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 11 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+人手または外部環境でしか確認できない証跡を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-12.md
@@ -1,0 +1,78 @@
+# Phase 12: ドキュメント更新 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 12 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 05b-B-magic-link-callback-credentials-provider
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 05b-B-magic-link-callback-credentials-provider |
+| phase | 13 / 13 |
+| wave | 05b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+ユーザー承認後のPR作成条件だけを定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-05b-authjs-callback-route-credentials-provider-001.md
+- apps/api/src/routes/auth/index.ts
+- apps/web/app/lib/auth/config.ts
+- apps/web/src/lib/auth.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/05b-B-magic-link-callback-credentials-provider/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05b Magic Link 発行・検証 API, 06b member login UI, AUTH_SECRET / NEXTAUTH_URL 相当の環境変数
+- 下流: 06b logged-in profile visual evidence, 08b auth E2E full execution, 09a staging auth smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- `/api/auth/callback/email?token=&email=` が 404 にならない
+- 正しい token/email で session cookie が確立される
+- 不正 token/email は login error に戻される
+- apps/web から D1 直参照せず API/proxy 境界を守る
+- 関連 route/auth tests が追加される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/artifacts.json
@@ -1,0 +1,217 @@
+{
+  "task_name": "06a-A-public-web-real-workers-d1-smoke-execution",
+  "task_path": "docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution",
+  "wave": "6a-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "04a public API",
+    "06a public web implementation",
+    "Cloudflare D1 binding"
+  ],
+  "blocks": [
+    "09a staging deploy smoke",
+    "08b Playwright E2E"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/30-workflows/completed-tasks/06a-A-public-web-real-workers-d1-smoke/",
+    "docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/specs/12-search-tags.md"
+  ],
+  "endpoints": [],
+  "d1_tables": [],
+  "ui_routes": [],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#5 public/member/admin boundary",
+    "#6 apps/web から D1 直接アクセス禁止",
+    "#8 localStorage/GAS prototype を正本にしない",
+    "#14 Cloudflare free-tier"
+  ],
+  "doc_references": [
+    "docs/30-workflows/completed-tasks/06a-A-public-web-real-workers-d1-smoke/",
+    "docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/specs/12-search-tags.md"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/index.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/index.md
@@ -1,0 +1,104 @@
+# 06a-A-public-web-real-workers-d1-smoke-execution
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 6a-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL |
+
+## purpose
+
+06a public web の local mock smoke では未検証だった real Workers + D1 経路を実測する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、正本上で未実装・未実測として残った follow-up gate だけを扱う。
+
+06a 本体は公開4 routeを実装済みだが、wrangler dev mismatch により実 Workers/D1 smoke が deferred になっている。mock API の green は apps/web -> apps/api -> D1 の本番経路を保証しない。
+
+## scope in / out
+
+### Scope In
+- `/`, `/members`, `/members/[id]`, `/register` の real Workers/D1 local smoke
+- staging smoke の curl log と補助 screenshot 取得
+- `PUBLIC_API_BASE_URL` 経路、D1 binding、Workers runtime の確認
+- 06a 親タスクへの evidence link trace 更新
+
+### Scope Out
+- 公開画面の新機能追加
+- OGP / sitemap
+- mobile FilterBar / tag picker
+- production deploy
+
+## dependencies
+
+### Depends On
+- 04a public API
+- 06a public web implementation
+- Cloudflare D1 binding
+
+### Blocks
+- 09a staging deploy smoke
+- 08b Playwright E2E
+
+## refs
+
+- docs/30-workflows/completed-tasks/06a-A-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## AC
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-01/main.md
@@ -1,0 +1,5 @@
+# outputs phase 01: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 要件定義
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-02/main.md
@@ -1,0 +1,5 @@
+# outputs phase 02: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 設計
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-03/main.md
@@ -1,0 +1,5 @@
+# outputs phase 03: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 設計レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-04/main.md
@@ -1,0 +1,5 @@
+# outputs phase 04: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: テスト戦略
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-05/main.md
@@ -1,0 +1,5 @@
+# outputs phase 05: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 実装ランブック
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-06/main.md
@@ -1,0 +1,5 @@
+# outputs phase 06: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 異常系検証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-07/main.md
@@ -1,0 +1,5 @@
+# outputs phase 07: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: AC マトリクス
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-08/main.md
@@ -1,0 +1,5 @@
+# outputs phase 08: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: DRY 化
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-09/main.md
@@ -1,0 +1,5 @@
+# outputs phase 09: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 品質保証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-10/main.md
@@ -1,0 +1,5 @@
+# outputs phase 10: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 最終レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-11/main.md
@@ -1,0 +1,5 @@
+# outputs phase 11: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: 手動 smoke / 実測 evidence
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-12/main.md
@@ -1,0 +1,5 @@
+# outputs phase 12: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: ドキュメント更新
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/outputs/phase-13/main.md
@@ -1,0 +1,5 @@
+# outputs phase 13: 06a-A-public-web-real-workers-d1-smoke-execution
+
+- status: pending
+- purpose: PR 作成
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-01.md
@@ -1,0 +1,79 @@
+# Phase 1: 要件定義 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 1 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-02.md
@@ -1,0 +1,79 @@
+# Phase 2: 設計 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 2 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実行構造、evidence path、依存 matrix、rollback/skip 条件を設計する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-03.md
@@ -1,0 +1,79 @@
+# Phase 3: 設計レビュー — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 3 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+代替案、リスク、GO/NO-GO 条件をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-04.md
@@ -1,0 +1,79 @@
+# Phase 4: テスト戦略 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 4 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+unit/contract/E2E/manual smoke/authorization の検証戦略を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-05.md
@@ -1,0 +1,79 @@
+# Phase 5: 実装ランブック — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 5 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+コード実装または実行操作の runbook を定義する。実行自体はこの仕様書作成では行わない。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-06.md
@@ -1,0 +1,79 @@
+# Phase 6: 異常系検証 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 6 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+401/403/404/409/422/5xx、secret 不備、runtime drift、flaky を検証する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-07.md
@@ -1,0 +1,79 @@
+# Phase 7: AC マトリクス — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 7 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+AC と検証・evidence の対応表を作る。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-08.md
@@ -1,0 +1,79 @@
+# Phase 8: DRY 化 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 8 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+既存タスクとの重複、命名、evidence path、状態語彙を整理する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-09.md
@@ -1,0 +1,79 @@
+# Phase 9: 品質保証 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 9 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+free-tier、secret hygiene、a11y、運用リスクを確認する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-10.md
@@ -1,0 +1,79 @@
+# Phase 10: 最終レビュー — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 10 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+上流 gate と blocker を踏まえて GO/NO-GO を判定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-11.md
@@ -1,0 +1,79 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 11 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実測 evidence の取得手順と保存先を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-12.md
@@ -1,0 +1,79 @@
+# Phase 12: ドキュメント更新 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 12 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/phase-13.md
@@ -1,0 +1,79 @@
+# Phase 13: PR 作成 — 06a-A-public-web-real-workers-d1-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06a-A-public-web-real-workers-d1-smoke-execution |
+| phase | 13 / 13 |
+| wave | 6a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+commit / PR / deploy / production mutation の user approval gate を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/06a-followup-001-public-web-real-workers-d1-smoke/
+- docs/30-workflows/completed-tasks/06a-parallel-public-landing-directory-and-registration-pages/
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06a-A-public-web-real-workers-d1-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04a public API, 06a public web implementation, Cloudflare D1 binding
+- 下流: 09a staging deploy smoke, 08b Playwright E2E
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web から D1 直接アクセス禁止
+- #8 localStorage/GAS prototype を正本にしない
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- local real Workers/D1 smoke の curl log が保存されている
+- staging real Workers/D1 smoke の curl log が保存されている
+- 少なくとも公開4 route family の screenshot または HTML evidence が保存されている
+- mock API ではなく apps/web -> apps/api -> D1 経路であることが evidence に明記されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/artifacts.json
@@ -1,0 +1,87 @@
+{
+  "task": "06b-A-me-api-authjs-session-resolver",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "docsOnly": true,
+  "remainingOnly": true,
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/index.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/index.md
@@ -1,0 +1,116 @@
+# 06b-A-me-api-authjs-session-resolver
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+`/profile` が本番 Auth.js session cookie で `/me/*` API を利用できるよう、apps/api の session resolver 差し替え漏れを実装する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、ソースコード上で確認できた Auth.js session と /me API の接続漏れだけを扱う。
+
+`apps/web/app/profile/page.tsx` は cookie を `apps/api` に転送して `/me` と `/me/profile` を呼ぶ。しかし `apps/api/src/index.ts` の `/me` mount は development かつ `x-ubm-dev-session: 1` の dev token だけを session として解決している。Auth.js cookie/JWT を読む production resolver が未接続のため、ログイン済み profile 画面は本番/staging で 401 になる可能性が高い。これは visual evidence 不足ではなく backend 接続実装漏れである。
+
+## scope in / out
+
+### Scope In
+- `apps/api` `/me/*` 用 Auth.js JWT/cookie session resolver 実装
+- `authjs.session-token` / `__Secure-authjs.session-token` から JWT を抽出して `AUTH_SECRET` で検証
+- dev resolver と production resolver の責務分離
+- `/me` `/me/profile` の cookie-based route tests
+- staging profile smoke の前提更新
+
+### Scope Out
+- profile UI の再設計
+- Auth.js Google OAuth provider の置換
+- Magic Link callback 実装そのもの
+- production secret 値の記録
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 05a Auth.js Google OAuth session JWT
+- 05b Magic Link callback follow-up
+- 04b /me route implementation
+- AUTH_SECRET shared between apps/web and apps/api
+
+### Blocks
+- 06b-B-profile-self-service-request-ui（後続: 申請 UI smoke は production session が前提）
+- 06b-C-profile-logged-in-visual-evidence（後続: logged-in visual は production session が前提）
+- 08b profile/auth E2E
+- 09a staging authenticated smoke
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06b-A → 06b-B → 06b-C** の serial。
+- 本タスクが session resolver の単独 SRP を担い、後続 2 タスクの前提条件を確定する。
+
+## refs
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## AC
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-01/main.md
@@ -1,0 +1,17 @@
+# Output Phase 1: 要件定義
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-02/main.md
@@ -1,0 +1,17 @@
+# Output Phase 2: 設計
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-03/main.md
@@ -1,0 +1,17 @@
+# Output Phase 3: 設計レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-04/main.md
@@ -1,0 +1,17 @@
+# Output Phase 4: テスト戦略
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-05/main.md
@@ -1,0 +1,17 @@
+# Output Phase 5: 実装ランブック
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-06/main.md
@@ -1,0 +1,17 @@
+# Output Phase 6: 異常系検証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-07/main.md
@@ -1,0 +1,17 @@
+# Output Phase 7: AC マトリクス
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-08/main.md
@@ -1,0 +1,17 @@
+# Output Phase 8: DRY 化
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-09/main.md
@@ -1,0 +1,17 @@
+# Output Phase 9: 品質保証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-10/main.md
@@ -1,0 +1,17 @@
+# Output Phase 10: 最終レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-11/main.md
@@ -1,0 +1,17 @@
+# Output Phase 11: 手動 smoke / 実測 evidence
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-12/main.md
@@ -1,0 +1,17 @@
+# Output Phase 12: ドキュメント更新
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/outputs/phase-13/main.md
@@ -1,0 +1,17 @@
+# Output Phase 13: PR 作成
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-01.md
@@ -1,0 +1,82 @@
+# Phase 1: 要件定義 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 1 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-02.md
@@ -1,0 +1,82 @@
+# Phase 2: 設計 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 2 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+最小責務で実装・運用設計を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-03.md
@@ -1,0 +1,82 @@
+# Phase 3: 設計レビュー — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 3 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューする。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-04.md
@@ -1,0 +1,82 @@
+# Phase 4: テスト戦略 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 4 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+自動・手動・外部環境検証の境界を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-05.md
@@ -1,0 +1,82 @@
+# Phase 5: 実装ランブック — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 5 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実装または運用実行時の手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-06.md
@@ -1,0 +1,82 @@
+# Phase 6: 異常系検証 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 6 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+失敗時、未設定時、権限不足時の挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-07.md
@@ -1,0 +1,82 @@
+# Phase 7: AC マトリクス — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 7 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+受入条件と evidence path を一対一に対応付ける。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-08.md
@@ -1,0 +1,82 @@
+# Phase 8: DRY 化 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 8 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+重複手順、重複設定、重複責務を削減する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-09.md
@@ -1,0 +1,82 @@
+# Phase 9: 品質保証 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 9 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+型、lint、test、security、observability の品質 gate を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-10.md
@@ -1,0 +1,82 @@
+# Phase 10: 最終レビュー — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 10 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実行前の最終判断材料を揃える。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-11.md
@@ -1,0 +1,82 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 11 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+人手または外部環境でしか確認できない証跡を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-12.md
@@ -1,0 +1,82 @@
+# Phase 12: ドキュメント更新 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 12 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/phase-13.md
@@ -1,0 +1,82 @@
+# Phase 13: PR 作成 — 06b-A-me-api-authjs-session-resolver
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-A-me-api-authjs-session-resolver |
+| phase | 13 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+ユーザー承認後のPR作成条件だけを定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- apps/api/src/index.ts
+- apps/api/src/routes/me/index.ts
+- apps/api/src/middleware/session-guard.ts
+- apps/api/src/middleware/require-admin.ts
+- packages/shared/src/auth.ts
+- apps/web/src/lib/fetch/authed.ts
+- apps/web/app/profile/page.tsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 05a Auth.js Google OAuth session JWT, 05b Magic Link callback follow-up, 04b /me route implementation, AUTH_SECRET shared between apps/web and apps/api
+- 下流: 06b logged-in profile visual evidence, 08b profile/auth E2E, 09a staging authenticated smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #11 profile SSR auth gate
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- dev-only 経路と production session 経路を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- production/staging の `/me` が Auth.js cookie/JWT で 200 を返す
+- 未ログインまたは不正 JWT は 401 を返す
+- 削除済み member は 410、rules 未同意は authGateState で表現される
+- apps/web は D1 直参照せず cookie forwarding のまま成立する
+- dev-only `x-ubm-dev-session` 経路は production で無効のまま維持される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/artifacts.json
@@ -1,0 +1,87 @@
+{
+  "task": "06b-B-profile-self-service-request-ui",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "docsOnly": true,
+  "remainingOnly": true,
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/index.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/index.md
@@ -1,0 +1,110 @@
+# 06b-B-profile-self-service-request-ui
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+`/profile` に本人の公開停止/再公開申請と退会申請 UI を追加する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、プロトタイプ・仕様書・現行ソースを突き合わせて確認した未反映箇所だけを扱う。
+
+仕様書 05-pages.md / 07-edit-delete.md / 09-ui-ux.md は `/profile` から公開停止と退会申請ができることを要求している。API 側は `POST /me/visibility-request` と `POST /me/delete-request` を実装済みだが、現行 UI は `StatusSummary`、Google Form 更新 CTA、回答表示、参加履歴のみで、申請 UI が存在しない。
+
+## scope in / out
+
+### Scope In
+- 公開停止/再公開申請フォームまたは確認ダイアログ
+- 退会申請フォームまたは確認ダイアログ
+- `/me/visibility-request` / `/me/delete-request` の client helper
+- pending/duplicate/error/success の UI 状態
+- profile visual/E2E evidence への追加
+
+### Scope Out
+- プロフィール本文のアプリ内編集
+- 管理者による即時削除処理
+- admin request queue の大規模再設計
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 04b /me self-service API
+- 06b profile page
+- 06b-A-me-api-authjs-session-resolver（先行必須: production session が解決していない状態で申請 UI smoke は不可）
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06b-A → 06b-B → 06b-C** の serial。
+- 本タスクは 06b-A 完了後に着手し、完了後に 06b-C が visual evidence を取得する。
+
+### Blocks
+- 06b-C-profile-logged-in-visual-evidence
+- 08b profile E2E full execution
+
+## refs
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## AC
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-01/main.md
@@ -1,0 +1,17 @@
+# Output Phase 1: 要件定義
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-02/main.md
@@ -1,0 +1,17 @@
+# Output Phase 2: 設計
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-03/main.md
@@ -1,0 +1,17 @@
+# Output Phase 3: 設計レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-04/main.md
@@ -1,0 +1,17 @@
+# Output Phase 4: テスト戦略
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-05/main.md
@@ -1,0 +1,17 @@
+# Output Phase 5: 実装ランブック
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-06/main.md
@@ -1,0 +1,17 @@
+# Output Phase 6: 異常系検証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-07/main.md
@@ -1,0 +1,17 @@
+# Output Phase 7: AC マトリクス
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-08/main.md
@@ -1,0 +1,17 @@
+# Output Phase 8: DRY 化
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-09/main.md
@@ -1,0 +1,17 @@
+# Output Phase 9: 品質保証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-10/main.md
@@ -1,0 +1,17 @@
+# Output Phase 10: 最終レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-11/main.md
@@ -1,0 +1,17 @@
+# Output Phase 11: 手動 smoke / 実測 evidence
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-12/main.md
@@ -1,0 +1,17 @@
+# Output Phase 12: ドキュメント更新
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/outputs/phase-13/main.md
@@ -1,0 +1,17 @@
+# Output Phase 13: PR 作成
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-01.md
@@ -1,0 +1,80 @@
+# Phase 1: 要件定義 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 1 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-02.md
@@ -1,0 +1,80 @@
+# Phase 2: 設計 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 2 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+最小責務で実装・運用設計を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-03.md
@@ -1,0 +1,80 @@
+# Phase 3: 設計レビュー — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 3 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューする。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-04.md
@@ -1,0 +1,80 @@
+# Phase 4: テスト戦略 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 4 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+自動・手動・外部環境検証の境界を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-05.md
@@ -1,0 +1,80 @@
+# Phase 5: 実装ランブック — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 5 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実装または運用実行時の手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-06.md
@@ -1,0 +1,80 @@
+# Phase 6: 異常系検証 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 6 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+失敗時、未設定時、権限不足時の挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-07.md
@@ -1,0 +1,80 @@
+# Phase 7: AC マトリクス — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 7 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+受入条件と evidence path を一対一に対応付ける。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-08.md
@@ -1,0 +1,80 @@
+# Phase 8: DRY 化 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 8 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+重複手順、重複設定、重複責務を削減する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-09.md
@@ -1,0 +1,80 @@
+# Phase 9: 品質保証 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 9 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+型、lint、test、security、observability の品質 gate を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-10.md
@@ -1,0 +1,80 @@
+# Phase 10: 最終レビュー — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 10 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実行前の最終判断材料を揃える。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-11.md
@@ -1,0 +1,80 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 11 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+人手または外部環境でしか確認できない証跡を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-12.md
@@ -1,0 +1,80 @@
+# Phase 12: ドキュメント更新 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 12 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/phase-13.md
@@ -1,0 +1,80 @@
+# Phase 13: PR 作成 — 06b-B-profile-self-service-request-ui
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-B-profile-self-service-request-ui |
+| phase | 13 / 13 |
+| wave | 06b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+ユーザー承認後のPR作成条件だけを定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未反映の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- apps/web/app/profile/page.tsx
+- apps/web/app/profile/_components/EditCta.tsx
+- apps/api/src/routes/me/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-B-profile-self-service-request-ui/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me self-service API, 06b profile page, 06b Auth.js session resolver follow-up
+- 下流: 06b logged-in profile visual evidence, 08b profile E2E full execution
+
+## 多角的チェック観点
+
+- #4 profile body edit forbidden
+- #5 apps/web D1 direct access forbidden
+- #11 member self-service boundary
+- 未実装/未実測を PASS と扱わない。
+- プロトタイプと仕様書の採用/不採用を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- マイページから公開停止/再公開申請を送れる
+- マイページから退会申請を送れる
+- 二重申請 409 をユーザーに分かる形で表示する
+- 本文編集 UI は追加しない
+- 申請 UI のスクリーンショット/E2E が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/artifacts.json
@@ -1,0 +1,215 @@
+{
+  "task_name": "06b-C-profile-logged-in-visual-evidence",
+  "task_path": "docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence",
+  "wave": "6b-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "04b /me and /me/profile",
+    "05a/05b session establishment",
+    "06b profile page"
+  ],
+  "blocks": [
+    "08b Playwright profile scenario",
+    "09a staging visual smoke"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md",
+    "docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/07-edit-delete.md"
+  ],
+  "endpoints": [],
+  "d1_tables": [],
+  "ui_routes": [],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#4 本文更新は Google Form 再回答のみ",
+    "#5 public/member/admin boundary",
+    "#8 localStorage/GAS prototype を正本にしない",
+    "#11 管理者も他人本文を直接編集しない"
+  ],
+  "doc_references": [
+    "docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md",
+    "docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/07-edit-delete.md"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/index.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/index.md
@@ -1,0 +1,109 @@
+# 06b-C-profile-logged-in-visual-evidence
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 6b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL |
+
+## purpose
+
+06b `/profile` の logged-in visual evidence を取得し、read-only 境界を実画面で確認する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、正本上で未実装・未実測として残った follow-up gate だけを扱う。
+
+06b 本体は `/login` screenshot と `/profile` redirect curl まで取得済みだが、ログイン済み session + `/me` `/me/profile` 実データでの profile screenshot は未取得である。
+
+## scope in / out
+
+### Scope In
+- logged-in `/profile` screenshot M-08 取得
+- 本文編集 form/input/textarea/submit が存在しないことの M-09 evidence
+- `/profile?edit=true` でも read-only 維持の M-10 evidence
+- staging M-14〜M-16 visual evidence
+
+### Scope Out
+- profile 本文編集 UI の追加
+- Magic Link retry-after UI 復元
+- 新規 member API 実装
+- production deploy
+
+## dependencies
+
+### Depends On
+- 04b /me and /me/profile
+- 05a/05b session establishment
+- 06b profile page
+- 06b-A-me-api-authjs-session-resolver（先行: production session 解決が前提）
+- 06b-B-profile-self-service-request-ui（先行: 申請 UI 反映後の visual 取得）
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06b-A → 06b-B → 06b-C** の serial。
+- 002 完了で `/me` が production session で 200 → 003 で申請 UI を実装 → 001 で logged-in visual + 申請 UI evidence を取得。
+
+### Blocks
+- 08b Playwright profile scenario
+- 09a staging visual smoke
+
+## refs
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## AC
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-01/main.md
@@ -1,0 +1,5 @@
+# outputs phase 01: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 要件定義
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-02/main.md
@@ -1,0 +1,5 @@
+# outputs phase 02: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 設計
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-03/main.md
@@ -1,0 +1,5 @@
+# outputs phase 03: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 設計レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-04/main.md
@@ -1,0 +1,5 @@
+# outputs phase 04: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: テスト戦略
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-05/main.md
@@ -1,0 +1,5 @@
+# outputs phase 05: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 実装ランブック
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-06/main.md
@@ -1,0 +1,5 @@
+# outputs phase 06: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 異常系検証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-07/main.md
@@ -1,0 +1,5 @@
+# outputs phase 07: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: AC マトリクス
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-08/main.md
@@ -1,0 +1,5 @@
+# outputs phase 08: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: DRY 化
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-09/main.md
@@ -1,0 +1,5 @@
+# outputs phase 09: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 品質保証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-10/main.md
@@ -1,0 +1,5 @@
+# outputs phase 10: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 最終レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-11/main.md
@@ -1,0 +1,5 @@
+# outputs phase 11: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: 手動 smoke / 実測 evidence
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-12/main.md
@@ -1,0 +1,5 @@
+# outputs phase 12: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: ドキュメント更新
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/outputs/phase-13/main.md
@@ -1,0 +1,5 @@
+# outputs phase 13: 06b-C-profile-logged-in-visual-evidence
+
+- status: pending
+- purpose: PR 作成
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 1 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 2 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実行構造、evidence path、依存 matrix、rollback/skip 条件を設計する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 3 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+代替案、リスク、GO/NO-GO 条件をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 4 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+unit/contract/E2E/manual smoke/authorization の検証戦略を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 5 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+コード実装または実行操作の runbook を定義する。実行自体はこの仕様書作成では行わない。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 6 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+401/403/404/409/422/5xx、secret 不備、runtime drift、flaky を検証する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 7 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+AC と検証・evidence の対応表を作る。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 8 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+既存タスクとの重複、命名、evidence path、状態語彙を整理する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 9 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+free-tier、secret hygiene、a11y、運用リスクを確認する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 10 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+上流 gate と blocker を踏まえて GO/NO-GO を判定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 11 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実測 evidence の取得手順と保存先を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-12.md
@@ -1,0 +1,78 @@
+# Phase 12: ドキュメント更新 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 12 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 06b-C-profile-logged-in-visual-evidence
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06b-C-profile-logged-in-visual-evidence |
+| phase | 13 / 13 |
+| wave | 6b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+commit / PR / deploy / production mutation の user approval gate を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/completed-tasks/UT-06B-PROFILE-VISUAL-EVIDENCE.md
+- docs/30-workflows/completed-tasks/06b-parallel-member-login-and-profile-pages/
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06b-C-profile-logged-in-visual-evidence/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 04b /me and /me/profile, 05a/05b session establishment, 06b profile page
+- 下流: 08b Playwright profile scenario, 09a staging visual smoke
+
+## 多角的チェック観点
+
+- #4 本文更新は Google Form 再回答のみ
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #11 管理者も他人本文を直接編集しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- M-08 profile screenshot が保存されている
+- M-09 no-form evidence で編集 form/input/textarea/submit が 0 件
+- M-10 edit query ignored evidence が保存されている
+- manual-smoke-evidence の該当行が captured に更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/artifacts.json
@@ -1,0 +1,189 @@
+{
+  "task_name": "06c-A-admin-dashboard",
+  "task_path": "docs/30-workflows/02-application-implementation/06c-A-admin-dashboard",
+  "wave": "06c-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "06b-A-me-api-authjs-session-resolver",
+    "06c-admin-pages-main",
+    "require-admin-middleware"
+  ],
+  "blocks": [
+    "06c-B-admin-members",
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "remaining_only": true,
+    "scope": "application_implementation",
+    "visualEvidence": "VISUAL_ON_EXECUTION"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-01/main.md"],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-02/main.md"],
+      "depends_on_phases": [1],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-03/main.md"],
+      "depends_on_phases": [2],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-04/main.md"],
+      "depends_on_phases": [3],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-05/main.md"],
+      "depends_on_phases": [4],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-06/main.md"],
+      "depends_on_phases": [5],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-07/main.md"],
+      "depends_on_phases": [6],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-08/main.md"],
+      "depends_on_phases": [7],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-09/main.md"],
+      "depends_on_phases": [8],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-10/main.md"],
+      "depends_on_phases": [9],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-11/main.md"],
+      "depends_on_phases": [10],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md",
+        "outputs/phase-12/implementation-guide.md",
+        "outputs/phase-12/system-spec-update-summary.md",
+        "outputs/phase-12/documentation-changelog.md",
+        "outputs/phase-12/unassigned-task-detection.md",
+        "outputs/phase-12/skill-feedback-report.md",
+        "outputs/phase-12/phase12-task-spec-compliance-check.md"
+      ],
+      "depends_on_phases": [11],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md",
+        "outputs/phase-13/local-check-result.md",
+        "outputs/phase-13/change-summary.md",
+        "outputs/phase-13/pr-template.md"
+      ],
+      "depends_on_phases": [12],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md"
+  ],
+  "endpoints": [
+    "GET /api/admin/dashboard",
+    "GET /api/admin/dashboard/kpi",
+    "GET /api/admin/dashboard/recent-actions"
+  ],
+  "d1_tables": [
+    "members",
+    "membership_requests",
+    "audit_log"
+  ],
+  "ui_routes": [
+    "/admin"
+  ],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#5 public/member/admin boundary",
+    "#11 管理者も他人本文を直接編集しない",
+    "#13 admin audit logging",
+    "#15 Auth session boundary"
+  ],
+  "doc_references": [
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/index.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/index.md
@@ -1,0 +1,116 @@
+# 06c-A-admin-dashboard
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06c-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+管理者ダッシュボード `/admin` を、`docs/00-getting-started-manual/specs/11-admin-management.md` および `claude-design-prototype/pages-admin.jsx` の dashboard 機能に整合させるための follow-up 仕様書を作成する。本仕様書は spec のみを生成し、アプリケーション実装は行わない。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、admin 本体実装後にプロトタイプと現状コードの差分として残った dashboard 領域だけを扱う。
+
+`/admin` ルートは admin role と require-admin middleware による二段防御で保護される設計だが、現状は KPI tile / 直近 7 日のアクション / pending request 件数 / 未解決 audit 件数を表示する集計 UI と対応 API（`/api/admin/dashboard` 系）が未接続である。プロトタイプ `pages-admin.jsx` の dashboard セクションを正本仕様 11-admin-management.md に整合させ、UI 構成、集計 endpoint、認可境界、audit logging を spec として確定させる。
+
+## scope in / out
+
+### Scope In
+- `/admin` dashboard 画面の UI 構成（KPI tile / 直近アクション / ショートカット導線）の仕様化
+- 集計 API（`/api/admin/dashboard` 等）の endpoint / response shape の仕様化
+- admin role 二段防御（middleware + require-admin API）の責務分離記述
+- audit log への dashboard 閲覧記録方針
+- pending request 件数 / 未解決 audit 件数 / 公開メンバー数 KPI の集計ソース定義
+
+### Scope Out
+- アプリケーション実装コードの追加・変更
+- admin 権限自体の付与フロー再設計
+- admin 詳細画面（member 編集 / request 承認 UI）の仕様（別 followup で扱う）
+- production secret 値の記録
+- 未承認 commit / push / PR
+
+## dependencies
+
+### Depends On
+- 06b-A-me-api-authjs-session-resolver（admin session resolver の前提）
+- 06c admin pages 本体タスク（`/admin` 配下の routing と layout）
+- require-admin middleware 実装
+
+### Blocks
+- 06c-B-admin-members（admin shell 共通基盤を提供）
+- 08b-A-playwright-e2e-full-execution（admin E2E）
+- 09a-A-staging-deploy-smoke-execution（staging admin smoke）
+
+### 内部依存
+- 表記上は parallel だが、実依存は **06b-A → 06c admin pages 本体 → 06c-A（本タスク）** の順で実装可能になる。
+- 本タスクは dashboard 集計 API と UI tile の SRP を担い、後続 admin E2E / staging smoke の前提条件を確定する。
+- 06c-A〜E（admin 5 件）は実態として admin shell 共通基盤を共有する parallel-eligible だが、命名規則「sort 順 = 実行順」に従い名目上 serial として A → B → C → D → E の順で実行する。
+
+## refs
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## AC
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-01.md
@@ -1,0 +1,105 @@
+# Phase 1: 要件定義 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 1 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 1）
+
+### true issue
+- `/admin` dashboard の集計 UI / API がプロトタイプ仕様 11-admin-management.md / pages-admin.jsx に対し未接続である点が真の課題。
+- middleware / require-admin API の二段防御は別タスクで担保されるが、dashboard 固有の集計境界が未定義。
+
+### 依存境界
+- 上流: 06b-followup-002 session resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+### 価値とコスト
+- 価値: 管理者が公開メンバー数 / pending request 件数 / 未解決 audit 件数を即座に把握できる。
+- コスト: 集計 endpoint 1 系統と KPI tile component 群、audit log への閲覧記録 1 行。
+
+### 4 条件
+- 価値性: admin 業務の起点になる KPI を提供する。
+- 実現性: 既存 D1 テーブル（members / membership_requests / audit_log）の集計のみで実装可能。
+- 整合性: #5 / #11 / #13 / #15 と矛盾しない。
+- 運用性: free-tier 範囲内、secret 値の追加なし。
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-02.md
@@ -1,0 +1,113 @@
+# Phase 2: 設計 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 2 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+dashboard 集計 API と UI tile の構造、env、依存関係を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 2）
+
+### Mermaid 構造図
+
+```mermaid
+flowchart LR
+  Browser -->|cookie| WebMiddleware[apps/web middleware<br/>admin role gate]
+  WebMiddleware --> AdminPage[/admin page SSR]
+  AdminPage -->|cookie forward| ApiRequireAdmin[apps/api require-admin]
+  ApiRequireAdmin --> DashboardRoute[/api/admin/dashboard]
+  DashboardRoute --> D1[(D1: members / membership_requests / audit_log)]
+  DashboardRoute --> AuditWriter[audit_log writer]
+```
+
+### env / dependency matrix
+
+| 項目 | 値 |
+| --- | --- |
+| 新規 env | なし |
+| 既存利用 env | AUTH_SECRET（session 検証）/ DB binding |
+| 新規依存ライブラリ | なし |
+| 影響パッケージ | apps/api, apps/web, packages/shared |
+
+### module 設計
+- apps/api: `routes/admin/dashboard.ts`（KPI 集計） / `services/admin/dashboard-aggregator.ts`
+- apps/web: `app/admin/page.tsx`（dashboard SSR） / `components/admin/KpiTile.tsx` / `components/admin/RecentActionsList.tsx`
+- packages/shared: `admin/dashboard-contract.ts`（API response schema）
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-03.md
@@ -1,0 +1,100 @@
+# Phase 3: 設計レビュー — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 3 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+代替案を比較評価し、Phase 2 の設計を PASS-MINOR-MAJOR で判定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 3）
+
+### 代替案
+1. **集計 endpoint を 1 本に集約**（採用候補）: `/api/admin/dashboard` で KPI と直近アクションをまとめて返す。
+2. **endpoint を分割**: `/api/admin/dashboard/kpi` と `/api/admin/dashboard/recent-actions` を別系統にする。
+3. **dashboard SSR で D1 直参照**: 不変条件 #5 違反のため不採用。
+
+### PASS-MINOR-MAJOR 判定
+- 案 1: PASS（呼び出し回数最小、cache 戦略一本化）
+- 案 2: MINOR（独立 cache が可能だが over-engineering）
+- 案 3: MAJOR（不変条件違反）
+
+### 採用方針
+案 1 を採用し、将来 cache 分離が必要になった時点で案 2 に分解する。
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-04.md
@@ -1,0 +1,97 @@
+# Phase 4: テスト戦略 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 4 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+unit / contract / E2E / authorization の verify suite を設計する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 4）
+
+### verify suite
+
+| 種別 | 対象 | 目的 |
+| --- | --- | --- |
+| unit | dashboard-aggregator | KPI 集計関数の境界条件 |
+| contract | /api/admin/dashboard | response shape と admin role gate |
+| authorization | require-admin | non-admin → 403 / admin → 200 |
+| E2E | /admin SSR | KPI tile 表示と直近アクション一覧描画 |
+| audit | audit_log writer | dashboard 閲覧が記録される |
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-05.md
@@ -1,0 +1,117 @@
+# Phase 5: 実装ランブック — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 5 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+実装手順、placeholder、擬似コード、sanity check を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 5）
+
+### runbook 概要
+1. apps/api `routes/admin/dashboard.ts` を追加し、require-admin middleware の下にマウント
+2. `services/admin/dashboard-aggregator.ts` に集計関数を実装
+3. apps/web `app/admin/page.tsx` で fetch し、KPI tile / 直近アクション component を描画
+4. packages/shared に response schema を追加
+5. audit_log への閲覧記録を組み込む
+
+### placeholder
+- KPI 件数の閾値色分け基準
+- 直近アクションの表示件数（既定 20 件）
+
+### 擬似コード
+
+```ts
+// services/admin/dashboard-aggregator.ts
+export async function aggregateDashboard(db: D1Database) {
+  const [publicMembers, pendingRequests, openAudits, recent] = await Promise.all([
+    db.prepare("SELECT count(*) FROM members WHERE visibility='public'").first(),
+    db.prepare("SELECT count(*) FROM membership_requests WHERE status='pending'").first(),
+    db.prepare("SELECT count(*) FROM audit_log WHERE resolved_at IS NULL").first(),
+    db.prepare("SELECT * FROM audit_log ORDER BY created_at DESC LIMIT 20").all(),
+  ]);
+  return { kpi: { publicMembers, pendingRequests, openAudits }, recent };
+}
+```
+
+### sanity check
+- non-admin で 403、admin で 200
+- KPI 件数が D1 直接 query と一致
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-06.md
@@ -1,0 +1,97 @@
+# Phase 6: 異常系検証 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 6 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+401 / 403 / 404 / 422 / 5xx の failure case と挙動を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 6）
+
+### failure cases
+
+| code | 条件 | 期待挙動 |
+| --- | --- | --- |
+| 401 | session 不正 / 未ログイン | apps/api が JSON で 401 |
+| 403 | session 有効だが admin role なし | require-admin が 403、middleware は 302 で /login |
+| 404 | endpoint typo | `/api/admin/dashboard` 以外は 404 |
+| 422 | query parameter 不正（将来の filter 用） | zod parse 失敗で 422 |
+| 5xx | D1 binding 不在 / migration 未適用 | log 記録の上 500、UI は error boundary |
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-07.md
@@ -1,0 +1,98 @@
+# Phase 7: AC マトリクス — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 7 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+Phase 1 AC × Phase 4 検証 × Phase 5 実装の対応を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 7）
+
+### AC マトリクス
+
+| AC | Phase 4 検証 | Phase 5 実装 |
+| --- | --- | --- |
+| `/admin` admin 二段防御 | authorization suite | middleware + require-admin |
+| KPI tile 表示 | contract + E2E | dashboard-aggregator + KpiTile |
+| 直近 7 日アクション | E2E | RecentActionsList |
+| non-admin 302/403 | authorization suite | middleware redirect / require-admin |
+| audit log 記録 | audit suite | audit writer hook |
+| apps/web D1 直参照禁止 | contract | cookie forward only |
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-08.md
@@ -1,0 +1,97 @@
+# Phase 8: DRY 化 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 8 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+命名・型・path・endpoint の Before / After を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 8）
+
+### Before / After
+
+| 項目 | Before | After |
+| --- | --- | --- |
+| endpoint | なし | `GET /api/admin/dashboard` |
+| component | なし | `KpiTile` / `RecentActionsList` |
+| service | なし | `aggregateDashboard()` |
+| schema | なし | `AdminDashboardResponse`（packages/shared） |
+| middleware path | `/admin/*` 未集約 | `/admin/*` で require-admin 一括適用 |
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-09.md
@@ -1,0 +1,101 @@
+# Phase 9: 品質保証 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 9 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+free-tier 見積もり / secret hygiene / a11y を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 9）
+
+### free-tier 見積もり
+- D1 read: 1 dashboard 表示 = 4 query。admin 操作頻度想定で daily 100 表示 → 400 read。free-tier 上限内。
+- Workers requests: dashboard 同期表示で +1 request/表示。
+
+### secret hygiene
+- [ ] 新規 secret 追加なし
+- [ ] AUTH_SECRET の値を log/doc に書かない
+- [ ] admin email allowlist は code に固定値で書かない（既存 env 参照）
+
+### a11y
+- KPI tile は h2 / h3 で見出し階層を保つ
+- 件数表示には aria-label で「○件」を含める
+- color contrast WCAG AA 準拠
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-10.md
@@ -1,0 +1,100 @@
+# Phase 10: 最終レビュー — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 10 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+GO/NO-GO 判定と blocker 一覧を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 10）
+
+### GO/NO-GO 判定
+
+| 観点 | 判定 | 理由 |
+| --- | --- | --- |
+| 仕様完全性 | GO | AC / failure / runbook 揃い |
+| 不変条件整合 | GO | #5 #11 #13 #15 違反なし |
+| 無料枠 | GO | 上限内 |
+| 実装着手準備 | GO | placeholder と擬似コード提示済み |
+
+### blocker 一覧
+- 06b-A session resolver 未完了の場合は実装着手不可
+- 06c admin pages 本体未完了の場合は `/admin` layout が存在しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-11.md
@@ -1,0 +1,97 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 11 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+screenshot / curl / wrangler 出力 placeholder を含む manual evidence を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 11）
+
+### manual evidence
+
+| 項目 | placeholder |
+| --- | --- |
+| screenshot | `outputs/phase-11/admin-dashboard-200.png` |
+| curl 200 | `curl -b cookie.txt $API/api/admin/dashboard` の出力 placeholder |
+| curl 403 | non-admin cookie で 403 を確認 |
+| wrangler tail | dashboard 閲覧時の audit_log insert ログ placeholder |
+| a11y | axe-core scan 結果 placeholder |
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-12.md
@@ -1,0 +1,102 @@
+# Phase 12: ドキュメント更新 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 12 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 12）
+
+### 中学生レベル概念説明（implementation-guide.md 抜粋）
+
+- **管理者ダッシュボードってなに？**: 学校の職員室にある「掲示板」のようなもの。生徒数、提出物の未受領件数、まだ対応していない相談件数が一目で分かる。
+- **二段防御の例え**: 校門で生徒証チェック（middleware）、職員室の入口でもう一度顔パス（require-admin API）。どちらか抜けても入れない仕組み。
+- **集計 API の例え**: 給食センターが各クラスの注文数をまとめて 1 枚の紙にして返してくれる。ブラウザは紙を見るだけで、台所（D1）には入らない。
+- **audit log の例え**: 職員室に入った人が必ずノートに名前を書く。誰がいつダッシュボードを見たか後から確認できる。
+
+### 想定 outputs（6 ファイル）
+- `outputs/phase-12/implementation-guide.md`（中学生レベル概念説明 + 日常の例え話）
+- `outputs/phase-12/system-spec-update-summary.md`（11-admin-management.md への追記反映）
+- `outputs/phase-12/documentation-changelog.md`
+- `outputs/phase-12/unassigned-task-detection.md`
+- `outputs/phase-12/skill-feedback-report.md`
+- `outputs/phase-12/phase12-task-spec-compliance-check.md`
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/phase-13.md
@@ -1,0 +1,116 @@
+# Phase 13: PR 作成 — 06c-A-admin-dashboard
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-A-admin-dashboard |
+| phase | 13 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| 上流 | 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware |
+| 下流 | 08b admin E2E / 09a staging admin smoke |
+
+## 目的
+
+approval gate / local-check-result / change-summary / PR template を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 spec / prototype を確認する。完了条件: dashboard 機能の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/app/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-A-admin-dashboard/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06b-A-me-api-authjs-session-resolver / 06c admin pages 本体 / require-admin middleware
+- 下流: 08b admin E2E / 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary（apps/web D1 direct access forbidden を含む）
+- #11 管理者も他人本文を直接編集しない
+- #13 admin audit logging
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- prototype `pages-admin.jsx` の表現と正本仕様 11-admin-management.md を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- `/admin` は admin role 必須（middleware + require-admin API の二段防御）で保護される
+- KPI tile（公開メンバー数 / pending request 件数 / 未解決 audit 件数）が集計 API 経由で表示される
+- 直近 7 日のアクション一覧が dashboard 上で確認できる
+- 非 admin user が `/admin` にアクセスした場合、middleware で 302、API で 403 を返す
+- dashboard 閲覧は audit log に記録される（#13）
+- apps/web は D1 直参照せず apps/api 経由で集計データを取得する（#5）
+
+## 追加セクション（Phase 13）
+
+### approval gate
+- user 明示 GO がない限り commit / push / PR 作成を行わない。
+- Phase 10 の GO/NO-GO が GO であること。
+
+### local-check-result（placeholder）
+- `mise exec -- pnpm typecheck` PASS
+- `mise exec -- pnpm lint` PASS
+- `mise exec -- pnpm test` PASS
+
+### change-summary（placeholder）
+- 追加: dashboard endpoint / aggregator / UI components / shared schema
+- 変更: admin layout に dashboard link 追加
+- ドキュメント: 11-admin-management.md dashboard 節更新
+
+### PR template
+
+```markdown
+## Summary
+- /admin dashboard の KPI tile / 直近アクション / 集計 API を実装
+- require-admin の二段防御で保護、audit log 記録対応
+
+## Test plan
+- [ ] unit (dashboard-aggregator)
+- [ ] contract (/api/admin/dashboard)
+- [ ] authorization (admin / non-admin)
+- [ ] E2E (/admin SSR)
+- [ ] manual smoke + screenshot
+```
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+次タスクへ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/artifacts.json
@@ -1,0 +1,78 @@
+{
+  "task_name": "06c-B-admin-members",
+  "task_path": "docs/30-workflows/02-application-implementation/06c-B-admin-members",
+  "wave": "06c-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "06c-A-admin-dashboard",
+    "06c-admin-pages",
+    "06b-A-me-api-authjs-session-resolver",
+    "07-edit-delete",
+    "require-admin-middleware"
+  ],
+  "blocks": [
+    "06c-C-admin-tags",
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL_ON_EXECUTION"
+  },
+  "phases": [
+    { "phase": 1, "name": "要件定義", "file": "phase-01.md", "status": "pending", "outputs": ["outputs/phase-01/main.md"], "depends_on_phases": [], "user_approval_required": false },
+    { "phase": 2, "name": "設計", "file": "phase-02.md", "status": "pending", "outputs": ["outputs/phase-02/main.md"], "depends_on_phases": [1], "user_approval_required": false },
+    { "phase": 3, "name": "設計レビュー", "file": "phase-03.md", "status": "pending", "outputs": ["outputs/phase-03/main.md"], "depends_on_phases": [2], "user_approval_required": false },
+    { "phase": 4, "name": "テスト戦略", "file": "phase-04.md", "status": "pending", "outputs": ["outputs/phase-04/main.md"], "depends_on_phases": [3], "user_approval_required": false },
+    { "phase": 5, "name": "実装ランブック", "file": "phase-05.md", "status": "pending", "outputs": ["outputs/phase-05/main.md"], "depends_on_phases": [4], "user_approval_required": false },
+    { "phase": 6, "name": "異常系検証", "file": "phase-06.md", "status": "pending", "outputs": ["outputs/phase-06/main.md"], "depends_on_phases": [5], "user_approval_required": false },
+    { "phase": 7, "name": "AC マトリクス", "file": "phase-07.md", "status": "pending", "outputs": ["outputs/phase-07/main.md"], "depends_on_phases": [6], "user_approval_required": false },
+    { "phase": 8, "name": "DRY 化", "file": "phase-08.md", "status": "pending", "outputs": ["outputs/phase-08/main.md"], "depends_on_phases": [7], "user_approval_required": false },
+    { "phase": 9, "name": "品質保証", "file": "phase-09.md", "status": "pending", "outputs": ["outputs/phase-09/main.md"], "depends_on_phases": [8], "user_approval_required": false },
+    { "phase": 10, "name": "最終レビュー", "file": "phase-10.md", "status": "pending", "outputs": ["outputs/phase-10/main.md"], "depends_on_phases": [9], "user_approval_required": false },
+    { "phase": 11, "name": "手動 smoke", "file": "phase-11.md", "status": "pending", "outputs": ["outputs/phase-11/main.md"], "depends_on_phases": [10], "user_approval_required": false },
+    { "phase": 12, "name": "ドキュメント更新", "file": "phase-12.md", "status": "pending", "outputs": ["outputs/phase-12/main.md"], "depends_on_phases": [11], "user_approval_required": false },
+    { "phase": 13, "name": "PR 作成", "file": "phase-13.md", "status": "pending", "outputs": ["outputs/phase-13/main.md"], "depends_on_phases": [12], "user_approval_required": true }
+  ],
+  "specs_referenced": [
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/07-edit-delete.md",
+    "docs/00-getting-started-manual/specs/12-search-tags.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md"
+  ],
+  "endpoints": [
+    "GET /api/admin/members?q&zone&status&tag&sort",
+    "GET /api/admin/members/:id",
+    "POST /api/admin/members/:id/soft-delete",
+    "POST /api/admin/members/:id/restore",
+    "POST /api/admin/members/:id/role"
+  ],
+  "d1_tables": [
+    "members",
+    "member_tags",
+    "audit_logs"
+  ],
+  "ui_routes": [
+    "/admin/members",
+    "/admin/members/[id]"
+  ],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#4 本文編集禁止（admin も同じ）",
+    "#5 apps/web D1 direct access forbidden",
+    "#11 admin も他人本文編集不可",
+    "#13 admin 操作の audit log 必須"
+  ],
+  "doc_references": [
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/07-edit-delete.md",
+    "docs/00-getting-started-manual/specs/12-search-tags.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/index.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/index.md
@@ -1,0 +1,126 @@
+# 06c-B-admin-members
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06c-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+`/admin/members`（一覧・検索/フィルタ）と `/admin/members/[id]`（詳細・論理削除/復元・ロール変更・audit 表示）の admin UI と対応 API 接続を、`11-admin-management.md` / `07-edit-delete.md` / `12-search-tags.md` の正本仕様に整合させる follow-up 仕様書。実装は行わず spec のみを定義する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、06c admin pages 本体で骨組みのみ作成された admin members 画面に対し、検索/フィルタ仕様・論理削除/復元 API 接続・audit log 表示の未接続部分だけを切り出して扱う。
+
+`apps/web/app/admin/members/page.tsx` および `[id]/page.tsx` は SSR スケルトンのみで、`GET /api/admin/members` の検索パラメータ（`q` / `zone` / `status` / `tag` / `sort`）と詳細画面の soft-delete / restore / role 変更 API、`12-search-tags.md` の検索 contract を満たしていない。本タスクはこの欠損だけを対象とし、admin の他機能（CSV export / 統計 / 一括操作等）は scope 外とする。
+
+## scope in / out
+
+### Scope In
+- `/admin/members` 一覧 UI（検索フォーム、zone/status/tag フィルタ、sort、ページング）
+- `/admin/members/[id]` 詳細 UI（基本情報・role・audit log 表示・論理削除/復元・ロール変更導線）
+- `GET /api/admin/members?q&zone&status&tag&sort` の query 契約と response 契約
+- `GET /api/admin/members/:id` の response 契約（audit log 含む）
+- `POST /api/admin/members/:id/soft-delete` / `POST /api/admin/members/:id/restore` の admin authorize 境界
+- `POST /api/admin/members/:id/role` の role 変更と audit 記録
+- require-admin middleware 経由の admin guard
+- 不変条件 #4 / #5 / #11 / #13 の admin 適用
+
+### Scope Out
+- public/会員向け検索 UI
+- CSV エクスポート、一括操作、統計ダッシュボード
+- Google Form 再回答経路（本人更新は MVP では Form を正本）
+- admin user の招待/作成 flow
+- production secret 値の記録
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 06c-A-admin-dashboard（admin shell 共通基盤）
+- 06c admin pages 本体（`/admin/*` のレイアウト・auth gate）
+- 06b-A-me-api-authjs-session-resolver（admin session 解決の前提）
+- 07-edit-delete API（soft-delete / restore endpoint 実装）
+- apps/api `require-admin` middleware
+- 12-search-tags.md（admin 検索パラメータ契約）
+
+### Blocks
+- 06c-C-admin-tags（admin shell 共通基盤を引き継ぐ）
+- 08b-A-playwright-e2e-full-execution（admin members E2E）
+- 09a-A-staging-deploy-smoke-execution（admin staging smoke）
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06c-A（admin layout / guard）→ 06c-B（本タスク）→ 08b-A admin E2E** の serial。
+- 本タスクは admin members の単独 SRP を担い、後続 E2E と smoke の前提を確定する。
+- 06c-A〜E（admin 5 件）は実態として admin shell 共通基盤を共有する parallel-eligible だが、命名規則「sort 順 = 実行順」に従い名目上 serial として A → B → C → D → E の順で実行する。
+
+## refs
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/members/page.tsx
+- apps/web/app/admin/members/[id]/page.tsx
+- apps/api/src/routes/admin/members/index.ts
+- apps/api/src/middleware/require-admin.ts
+
+## AC
+
+- `/admin/members` で `q` / `zone` / `status` / `tag` / `sort` の組み合わせ検索が `12-search-tags.md` 通りに動作し、結果がページングされる。
+- `/admin/members/[id]` が基本情報・role・audit log を表示し、admin による soft-delete / restore / role 変更が成功・失敗で分岐表示される。
+- `GET /api/admin/members*` は admin 以外で 403、未ログインで 401 を返す。
+- soft-delete / restore は `07-edit-delete.md` の論理削除ポリシーに従い、`deletedAt` / `restoredAt` と audit log を記録する。
+- 不変条件 #4（本文編集禁止）, #5（apps/web D1 直参照禁止）, #11（admin も他人本文編集不可）, #13（audit log 必須）に違反しない。
+- production secret 値は仕様書中に登場しない。
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #4 本文編集禁止（admin も同じ）
+- #5 apps/web D1 direct access forbidden
+- #11 admin も他人本文編集不可
+- #13 admin 操作の audit log 必須
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-01.md
@@ -1,0 +1,85 @@
+# Phase 1: 要件定義 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 1 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+`/admin/members` 一覧と `/admin/members/[id]` 詳細の真の未完了境界を確定する。検索/フィルタ・論理削除/復元・ロール変更・audit 表示を `11-admin-management.md` / `07-edit-delete.md` / `12-search-tags.md` に整合させるため、scope と AC、依存・evidence path を明確化する。
+
+## 実行タスク
+
+1. 正本仕様（11/07/12 + 06/09）と prototype の admin members section を確認する。完了条件: 検索パラメータ・論理削除/復元・audit 表示の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/members/page.tsx
+- apps/web/app/admin/members/[id]/page.tsx
+- apps/api/src/routes/admin/members/index.ts
+- apps/api/src/middleware/require-admin.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver, 07-edit-delete API, require-admin middleware, 12-search-tags 検索契約
+- 下流: 08b admin members E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #4 本文編集禁止（admin も同じ）
+- #5 apps/web D1 direct access forbidden
+- #11 admin も他人本文編集不可
+- #13 admin 操作の audit log 必須
+- 4条件（価値性: admin 運用必須機能 / 実現性: 既存 require-admin で接続可 / 整合性: 11/07/12 の正本仕様準拠 / 運用性: audit log で操作追跡可能）
+- 未実装/未実測を PASS と扱わない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- 検索 query (`q` / `zone` / `status` / `tag` / `sort`) の契約が `12-search-tags.md` に整合する。
+- soft-delete / restore が `07-edit-delete.md` の論理削除ポリシーに従う。
+- admin 以外で 403、未ログインで 401 を返す。
+- audit log に操作主体・対象 memberId・操作種別・timestamp が記録される。
+- production secret 値が仕様書中に登場しない。
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-02.md
@@ -1,0 +1,110 @@
+# Phase 2: 設計 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 2 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+`/admin/members` 一覧 / 詳細の UI、API contract、D1 アクセス境界、middleware 連携を構造的に設計する。
+
+## 実行タスク
+
+1. `apps/web` の admin members SSR 構造（list / detail）を仕様化する。完了条件: route と data fetch 経路が決まる。
+2. `apps/api` 側の admin members route と D1 query / audit 書込みを仕様化する。完了条件: 5 endpoint の I/O 契約が決まる。
+3. dependency matrix（require-admin → route handler → D1 → audit）を整える。完了条件: 各層の責務が分離される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/members/page.tsx
+- apps/web/app/admin/members/[id]/page.tsx
+- apps/api/src/routes/admin/members/index.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 設計図（Mermaid）
+
+```mermaid
+flowchart LR
+  Browser[Admin Browser] -->|cookie| Web[apps/web /admin/members]
+  Web -->|forward cookie| API[apps/api /api/admin/members]
+  API --> Guard[require-admin middleware]
+  Guard --> Handler[members handler]
+  Handler --> D1[(D1: members / member_tags / audit_logs)]
+  Handler -->|write| Audit[(audit_logs)]
+```
+
+## env / dependency matrix
+
+| 層 | 入力 | 出力 | 依存 |
+| --- | --- | --- | --- |
+| apps/web list | cookie / search params | SSR HTML | apps/api GET list |
+| apps/web detail | cookie / `[id]` | SSR HTML + action forms | apps/api GET detail |
+| apps/api guard | cookie | session + admin role | AUTH_SECRET |
+| apps/api handler | query / body | JSON | D1 binding |
+| audit | actor / target / action | row | audit_logs table |
+
+## API contract
+
+- `GET /api/admin/members?q&zone&status&tag&sort&page` → `{ items: Member[], total, page, pageSize }`
+- `GET /api/admin/members/:id` → `{ member, auditLogs[] }`
+- `POST /api/admin/members/:id/soft-delete` → `{ id, deletedAt }`
+- `POST /api/admin/members/:id/restore` → `{ id, restoredAt }`
+- `POST /api/admin/members/:id/role` body: `{ role: "admin" | "member" }` → `{ id, role }`
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver, 07-edit-delete API, require-admin middleware
+- 下流: 08b admin members E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #4 本文編集禁止（admin も同じ）
+- #5 apps/web D1 direct access forbidden
+- #11 admin も他人本文編集不可
+- #13 admin 操作の audit log 必須
+- 検索パラメータが 12-search-tags.md と一致する
+- soft-delete / restore が 07-edit-delete.md と一致する
+
+## サブタスク管理
+
+- [ ] route 構造を決める
+- [ ] API 契約を決める
+- [ ] dependency matrix を決める
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- 5 endpoint の I/O が決定している
+- apps/web は cookie forwarding のみで D1 直参照しない
+- audit 書込み層が責務分離される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、設計図、API 契約、dependency matrix を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-03.md
@@ -1,0 +1,84 @@
+# Phase 3: 設計レビュー — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 3 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+Phase 2 の設計を 3 つ以上の代替案と比較し、不変条件と運用性で PASS / MINOR / MAJOR を判定する。
+
+## 実行タスク
+
+1. 代替案を 3 つ以上挙げる。完了条件: 各案の trade-off が記録される。
+2. 採用案と却下案の理由を明文化する。完了条件: PASS-MINOR-MAJOR 判定が記録される。
+3. blocker と未解決リスクを Phase 4 に渡す。完了条件: 引き渡し項目が決まる。
+
+## 代替案比較
+
+| 案 | 概要 | 採否 | 判定 |
+| --- | --- | --- | --- |
+| A: apps/web から D1 直参照 | SSR で D1 binding を直接呼ぶ | 却下 | MAJOR（不変条件 #5 違反） |
+| B: apps/api 経由 + cookie forwarding | 06b-A session resolver を再利用 | 採用 | PASS |
+| C: admin 専用 BFF を別 worker で建てる | 新 worker を追加 | 却下 | MAJOR（無料枠と運用負担） |
+| D: 検索を client-side filter で擬似実装 | クエリを使わず全件取得 | 却下 | MAJOR（性能・無料枠・12-search-tags 不整合） |
+| E: soft-delete を物理削除で代替 | DELETE で row を消す | 却下 | MAJOR（07-edit-delete 不整合・復元不可） |
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- apps/api/src/middleware/require-admin.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 2 設計
+- 下流: Phase 4 テスト戦略
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 の不変条件への適合
+- 認可境界（admin / member / guest）の網羅
+- 12-search-tags のクエリ仕様と整合
+- 07-edit-delete の論理削除/復元ポリシーと整合
+
+## サブタスク管理
+
+- [ ] 代替案を 3 案以上記録する
+- [ ] PASS-MINOR-MAJOR を判定する
+- [ ] blocker を Phase 4 に渡す
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- 採用案が PASS、却下案の MAJOR 理由が不変条件で説明される
+- 12-search-tags / 07-edit-delete に整合する案のみが採用されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、採用案・blocker・テスト対象 endpoint を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-04.md
@@ -1,0 +1,83 @@
+# Phase 4: テスト戦略 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 4 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+unit / contract / E2E / authorization の 4 層で admin members のテスト責務を切り分ける。
+
+## verify suite
+
+| 層 | 対象 | 例 |
+| --- | --- | --- |
+| unit | query builder（q/zone/status/tag/sort）, audit logger | 検索パラメータが SQL 句に正しく変換される |
+| contract | apps/api の 5 endpoint の I/O | `GET /api/admin/members?q=foo` の response shape |
+| authorization | require-admin middleware | guest=401 / member=403 / admin=200 |
+| E2E | apps/web 一覧→詳細→soft-delete→restore→role 変更 | Playwright（08b で実行） |
+
+## 実行タスク
+
+1. unit / contract / authorization の責務を割り当てる。完了条件: 各層が独立して落ちる前提条件が決まる。
+2. E2E（08b）への引き渡し項目を決める。完了条件: smoke で必要な fixture が決まる。
+3. 検索パラメータの組み合わせ table を作る。完了条件: 12-search-tags の網羅性が確認される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- apps/api/src/routes/admin/members/index.ts
+- apps/api/src/middleware/require-admin.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 3 採用案
+- 下流: Phase 5 実装ランブック / 08b admin members E2E
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 への適合をテストで担保する
+- 401 / 403 / 404 / 422 の境界条件を網羅する
+- audit_logs に書かれることを contract test で検証する
+
+## サブタスク管理
+
+- [ ] unit suite を定義する
+- [ ] contract suite を定義する
+- [ ] authorization suite を定義する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- 4 層のテスト責務が分離されている
+- 検索パラメータ組み合わせが網羅されている
+- audit 書込みが検証対象に含まれている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、テスト suite と 08b へ引き渡す fixture を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-05.md
@@ -1,0 +1,103 @@
+# Phase 5: 実装ランブック — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 5 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実装フェーズで使う runbook（順序・placeholder・sanity check）を定義する。
+
+## runbook
+
+1. apps/api 側に admin members の 5 endpoint を追加し、`require-admin` で wrap する。
+2. query builder（q/zone/status/tag/sort/page）を追加し、unit テストで合格させる。
+3. soft-delete / restore handler を `07-edit-delete.md` に従い実装し、audit_logs を書く。
+4. role 変更 handler に admin role 確認と audit 書込みを実装する。
+5. apps/web `/admin/members` 一覧 SSR を fetch + cookie forwarding で実装する。
+6. apps/web `/admin/members/[id]` 詳細を実装し、action 用 form を server action または fetch + revalidate で接続する。
+7. authorization unit / contract / authz suite が green になることを確認する。
+8. `mise exec -- pnpm typecheck && mise exec -- pnpm lint` を実行する（実装フェーズで）。
+
+## 擬似コード（参考のみ）
+
+```ts
+// apps/api/src/routes/admin/members/index.ts
+admin.get("/", requireAdmin, async (c) => {
+  const params = parseSearch(c.req.query());
+  const result = await listMembers(c.env.DB, params);
+  return c.json(result);
+});
+
+admin.post("/:id/soft-delete", requireAdmin, async (c) => {
+  const id = c.req.param("id");
+  const r = await softDelete(c.env.DB, id);
+  await writeAudit(c.env.DB, { actor, target: id, action: "soft-delete" });
+  return c.json(r);
+});
+```
+
+## sanity check
+
+- 401 / 403 が想定通りに返る
+- soft-delete 後に list で `status=deleted` filter を付けないと表示されない
+- restore 後は通常 list に戻る
+- audit_logs に actor / target / action / timestamp が揃う
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- apps/api/src/routes/admin/members/index.ts
+- apps/api/src/middleware/require-admin.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 4 テスト戦略
+- 下流: Phase 6 異常系検証
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 を実装段階で踏まない
+- 検索 query が SQL injection に対し parameterized になる
+- audit 書込みが失敗時 transaction で巻き戻される
+
+## サブタスク管理
+
+- [ ] runbook を確定する
+- [ ] sanity check 項目を確定する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- 実装担当が手順を見て独立に進められる
+- placeholder / 擬似コードが正本仕様に整合する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、runbook と sanity check を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-06.md
@@ -1,0 +1,86 @@
+# Phase 6: 異常系検証 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 6 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+401 / 403 / 404 / 409 / 422 / 5xx / sync 失敗 等の失敗ケースを網羅する。
+
+## failure cases
+
+| ケース | 期待 |
+| --- | --- |
+| 未ログイン | 401 / `/admin/members` は login へ redirect |
+| member ロールで admin API 叩く | 403 |
+| 存在しない id を soft-delete | 404 |
+| 既に soft-delete 済の対象を再 soft-delete | 409 (conflict) |
+| restore 対象が deletedAt=null | 409 |
+| role body が不正 (`role: "owner"`) | 422 |
+| audit_logs 書込み失敗 | 5xx + transaction rollback |
+| 検索 sort key が許可リスト外 | 422 |
+| ページ数が極端 (page=99999) | 200 + 空配列 |
+| q が長大 (>256 文字) | 422 |
+
+## 実行タスク
+
+1. 上記 case ごとに contract / unit テストの担当を決める。完了条件: 各 case が責任 layer に紐付く。
+2. audit_logs の rollback 動作を仕様化する。完了条件: 失敗時の整合性が決まる。
+3. apps/web 側の error UI（toast / inline）を 09-ui-ux.md と整合させる。完了条件: error 表示が決まる。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 5 runbook
+- 下流: Phase 7 AC マトリクス / 08b E2E
+
+## 多角的チェック観点
+
+- #11 admin も他人本文編集不可（更新系 422 で fail-fast）
+- #13 audit 必須（失敗時も書込みが落ちないよう transaction）
+- error UI が a11y / i18n に整合する
+
+## サブタスク管理
+
+- [ ] failure case を全件記述する
+- [ ] rollback 動作を仕様化する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- 401/403/404/409/422/5xx の境界が網羅される
+- audit 書込み失敗時の整合性が定義される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、failure case 一覧と AC を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-07.md
@@ -1,0 +1,84 @@
+# Phase 7: AC マトリクス — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 7 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+Phase 1 の AC × Phase 4 の検証 × Phase 5 の実装を 1 表に対応付け、抜け漏れを発見する。
+
+## AC マトリクス
+
+| AC | 検証層 (Phase 4) | 実装箇所 (Phase 5) | 失敗ケース (Phase 6) |
+| --- | --- | --- | --- |
+| 検索 q/zone/status/tag/sort が動作 | unit query builder + contract | apps/api list handler | sort 範囲外 422 |
+| ページングが動作 | contract | apps/api list handler | page 過大 → 空配列 |
+| 詳細が member + auditLogs を返す | contract | apps/api detail handler | 404 |
+| soft-delete | contract + authz | apps/api soft-delete handler | 409 重複 / 404 |
+| restore | contract + authz | apps/api restore handler | 409 / 404 |
+| role 変更 + audit 記録 | contract + authz | apps/api role handler | 422 不正 role |
+| admin 以外で 403 | authz | require-admin middleware | guest 401 / member 403 |
+| apps/web は cookie forwarding のみ | unit (web fetch util) | apps/web fetch helpers | D1 直参照を構造的に禁止 |
+| audit_logs 必須記録 | contract | audit writer | 書込み失敗時 5xx |
+
+## 実行タスク
+
+1. AC ごとの検証 / 実装 / 失敗対応を 1 表で確定する。完了条件: 全 AC に少なくとも 1 検証層が紐付く。
+2. 抜け漏れを Phase 8 / 9 への申し送りに記録する。完了条件: gap が文書化される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 1 AC, Phase 4 verify suite, Phase 5 runbook, Phase 6 failure cases
+- 下流: Phase 8 DRY 化
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 が AC に対応する検証層を持っている
+- 検索仕様が 12-search-tags と一致する
+- 論理削除/復元仕様が 07-edit-delete と一致する
+
+## サブタスク管理
+
+- [ ] AC × 検証 × 実装 × 失敗の 4 軸表を完成させる
+- [ ] gap を記録する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- 全 AC が検証層と実装に紐付く
+- 全 failure case が責任 layer を持つ
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC マトリクスと gap を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-08.md
@@ -1,0 +1,83 @@
+# Phase 8: DRY 化 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 8 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+命名・型・path・endpoint の Before/After を整え、admin 配下と me 配下の重複を抑制する。
+
+## Before / After
+
+| 領域 | Before | After |
+| --- | --- | --- |
+| 検索 query 型 | route 内に inline 定義 | `packages/shared/src/admin/search.ts` で `AdminMemberSearch` 型に集約 |
+| audit writer | handler 内で直接 INSERT | `apps/api/src/lib/audit.ts` に `writeAudit(actor, target, action)` を抽出 |
+| require-admin | 各 route で都度 check | middleware 1 箇所に統一（既存維持） |
+| apps/web fetch | route ごとに fetch 文を生 | `apps/web/src/lib/fetch/admin.ts` で `fetchAdminMembers()` |
+| endpoint path | `/api/admin/members/:id/delete` 等の混在 | `/api/admin/members/:id/soft-delete` `/restore` `/role` に統一 |
+| 命名 | `removeMember` / `disableMember` | `softDeleteMember` / `restoreMember` に統一（07-edit-delete 準拠） |
+
+## 実行タスク
+
+1. 重複 code path を列挙する。完了条件: refactor 対象が決まる。
+2. 命名と path を 11/07/12 に整合させる。完了条件: After に統一名が決まる。
+3. shared 化対象を packages/shared に切り出す方針を決める。完了条件: 配置先が決まる。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- packages/shared/src/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 7 AC マトリクス
+- 下流: Phase 9 品質保証
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden（fetch helper 経由）
+- #13 audit 書込みが 1 箇所に集約される
+- 命名が 07-edit-delete / 12-search-tags の語彙と一致する
+
+## サブタスク管理
+
+- [ ] Before/After 表を確定する
+- [ ] shared 化対象を決める
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- 命名・path・endpoint が正本仕様の語彙に統一される
+- 重複が packages/shared または lib/ に集約される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、Before/After と shared 化方針を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-09.md
@@ -1,0 +1,94 @@
+# Phase 9: 品質保証 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 9 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+無料枠見積もり、secret hygiene、a11y を確認する。
+
+## free-tier 見積もり
+
+| 項目 | 想定 | 限度 |
+| --- | --- | --- |
+| Workers requests | admin の list/detail で 1 操作あたり 数 req、想定 admin 数 1〜数名 | Cloudflare Workers free 100k/day 内 |
+| D1 reads | list 検索 1 回あたり 1〜2 query | D1 free 5M reads/day 内 |
+| D1 writes | soft-delete / restore / role + audit log = 各 2 write | 100k writes/day 内 |
+| Pages | 一覧最大 50 件/page で sort + index 利用 | 全件スキャン回避 |
+
+## secret hygiene チェックリスト
+
+- [ ] AUTH_SECRET / DATABASE 接続情報を仕様書中に記載していない
+- [ ] role 変更 audit に PII が漏れない（actor は memberId のみ、name は記載しない）
+- [ ] error response に内部 SQL や stack trace を含めない
+- [ ] apps/web 側で D1 binding を直参照しない（不変条件 #5）
+
+## a11y チェックリスト
+
+- [ ] 検索フォームに label が紐付く
+- [ ] table の column header が `<th scope="col">` で表現される
+- [ ] soft-delete / restore の confirmation が dialog で focus trap される
+- [ ] error toast が aria-live="polite" で読み上げられる
+- [ ] keyboard で 一覧→詳細→操作 まで到達できる
+
+## 実行タスク
+
+1. 無料枠見積もりを記録する。完了条件: 想定運用が無料枠内に収まる。
+2. secret hygiene を確認する。完了条件: 漏洩経路が無い。
+3. a11y を 09-ui-ux.md と整合させる。完了条件: WCAG AA 必須項目が満たされる。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 8 DRY
+- 下流: Phase 10 最終レビュー
+
+## 多角的チェック観点
+
+- #5 / #13 / a11y / 無料枠
+
+## サブタスク管理
+
+- [ ] 無料枠見積もり完了
+- [ ] secret hygiene 完了
+- [ ] a11y 完了
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- 無料枠で運用可能
+- secret 漏洩経路ゼロ
+- a11y AA 必須項目満たす
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、QA 結果を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-10.md
@@ -1,0 +1,84 @@
+# Phase 10: 最終レビュー — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 10 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+GO / NO-GO を判定し、blocker を一覧化する。
+
+## GO / NO-GO 判定基準
+
+- GO: AC マトリクスが全件埋まり、failure case 全件に責任 layer が紐付き、無料枠/secret/a11y チェックが全通過
+- NO-GO: 上記いずれかが未充足、または不変条件 #4 / #5 / #11 / #13 のいずれかに違反する設計
+
+## blocker 一覧（仕様書段階で想定される候補）
+
+| blocker | 内容 | 解消条件 |
+| --- | --- | --- |
+| B1 | 06b-A session resolver 未着地時は admin guard が dev token のみ | 06b-A 完了 |
+| B2 | audit_logs migration 未適用 | 07-edit-delete 系 migration を適用 |
+| B3 | require-admin の admin role 判定基準未確定 | 11-admin-management.md の role table 確認 |
+| B4 | 検索 index 不足 | members(zone, status) / member_tags(memberId, tag) に複合 index |
+
+## 実行タスク
+
+1. AC / failure / QA を再点検する。完了条件: gap がゼロ。
+2. blocker を列挙し、解消条件を書く。完了条件: 各 blocker に owner と入口が明示される。
+3. GO/NO-GO を判定する。完了条件: 結論が記録される。
+
+## 参照資料
+
+- 本仕様書の Phase 1〜9
+- docs/00-getting-started-manual/specs/11-admin-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 1〜9 全成果物
+- 下流: Phase 11 手動 smoke
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 すべての不変条件で違反なし
+- 上流タスク (06b-A) との依存解消順序
+
+## サブタスク管理
+
+- [ ] AC 再点検
+- [ ] blocker 一覧化
+- [ ] GO/NO-GO 判定
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- GO/NO-GO が記録されている
+- blocker と解消条件が記録されている
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、判定結果と blocker を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-11.md
@@ -1,0 +1,92 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 11 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実装後の手動 smoke と evidence 取得手順を定義する（実測そのものは本仕様書作成では行わない）。
+
+## manual evidence（取得対象 placeholder）
+
+| 種別 | path（placeholder） |
+| --- | --- |
+| screenshot 一覧 | outputs/phase-11/screenshots/admin-members-list.png |
+| screenshot 詳細 | outputs/phase-11/screenshots/admin-members-detail.png |
+| screenshot soft-delete confirm | outputs/phase-11/screenshots/admin-members-soft-delete.png |
+| curl GET list | outputs/phase-11/curl/admin-members-list.txt |
+| curl GET detail | outputs/phase-11/curl/admin-members-detail.txt |
+| curl POST soft-delete | outputs/phase-11/curl/admin-members-soft-delete.txt |
+| curl POST restore | outputs/phase-11/curl/admin-members-restore.txt |
+| curl POST role | outputs/phase-11/curl/admin-members-role.txt |
+| wrangler tail（admin handler ログ） | outputs/phase-11/wrangler-tail.txt |
+| audit_logs SELECT | outputs/phase-11/d1/audit-logs.txt |
+
+## smoke 手順 placeholder
+
+1. staging に admin role の test user で login し、`/admin/members` に到達する。
+2. 検索 q/zone/status/tag を組合せて結果が変わることを確認、screenshot 取得。
+3. 詳細画面を開き、audit log が表示されることを確認。
+4. soft-delete 実行し、list で `status=deleted` filter 時のみ表示されることを確認。
+5. restore 実行し、通常 list に戻ることを確認。
+6. role 変更を実行し、audit_logs に記録されることを D1 SELECT で確認。
+7. member ロールでアクセス → 403 を確認。
+8. 未ログインアクセス → 401 / login redirect を確認。
+
+> **注意**: 本仕様書作成タスクではこれらを実測しない。実測は実装担当者が Phase 5 完了後に行う。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 10 GO 判定
+- 下流: 09a admin staging smoke / Phase 12 ドキュメント更新
+
+## 多角的チェック観点
+
+- screenshot に PII（実会員 name / email）が映り込まない
+- curl 出力に Authorization header の値を残さない
+- evidence は staging 環境のものを使用し production を触らない
+
+## サブタスク管理
+
+- [ ] evidence path placeholder を確定する
+- [ ] smoke 手順を確定する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- evidence path placeholder が全件決まっている
+- smoke 手順が再現可能
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、evidence path と smoke 手順を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-12.md
@@ -1,0 +1,121 @@
+# Phase 12: ドキュメント更新 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 12 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+正本仕様、runbook、lessons learned、未割当タスクの同期を定義する。実装担当者でも理解できるように、概念を中学生レベルで言語化する。
+
+## 中学生レベル概念説明（日常の例え話つき）
+
+### 「論理削除（soft-delete）」とは
+
+データを本当に消すのではなく、「消したフラグ」を立てるだけの削除。
+
+> 例え話: 学校の出席簿で、転校した友達の名前を**消しゴムで消す（物理削除）**のではなく、**斜線を引いて『転校』と書く（論理削除）**ようなもの。後から「やっぱり戻ってきた」と言われても、復活できる。物理削除だと、ノートを破ってしまった後で名前を書き直すのは大変。
+
+### 「audit log（監査ログ）」とは
+
+「誰が、いつ、どのデータに、何をしたか」を残す記録。
+
+> 例え話: コンビニの**防犯カメラ**に近い。商品を取った人を後から確認できるようにするための録画。admin が「他の会員のロールを admin に変えた」など重要な操作をしたら、後から「いつ、誰が、誰に対して、どうしたか」を必ず追えるようにする。
+
+### 「admin guard（require-admin middleware）」とは
+
+「この入り口は admin 専用です」という札と鍵を扉につける仕組み。
+
+> 例え話: 学校の**職員室の鍵**。生徒（一般会員）はそもそも入れず、職員（admin）しか開けられない。鍵がない人がドアノブを回したら、自動で「入れません（403）」と返す。鍵自体を持っていない（ログインしていない）人にはそもそも「誰ですか？（401）」と返す。
+
+### 「検索 query パラメータ」とは
+
+URL の `?` の後ろに付ける条件指定。「どんな会員を一覧に出したいか」を URL で表す。
+
+> 例え話: 図書館で本を探すときの**検索カード**。「ジャンル: 小説」「著者: あ行」「貸出可」を組み合わせて目的の本を絞り込むのと同じ。URL に `?q=...&zone=...&status=...` と書くことで、サーバ側に「この条件で探して」と頼む。
+
+### 「不変条件 #5（apps/web は D1 直参照禁止）」とは
+
+ブラウザに近い側のサーバ（apps/web）は、データベースを直接触ってはいけないルール。必ず apps/api（API サーバ）を経由する。
+
+> 例え話: **学校の倉庫の鍵を、生徒に直接渡さない**ようなもの。生徒（apps/web）が必要なものは、必ず**事務員（apps/api）**にお願いして取ってきてもらう。直接倉庫に入れると、必要ないものまで持ち出される危険がある。
+
+## 更新対象ドキュメント
+
+- `outputs/phase-12/implementation-guide.md` — 実装手順の要約
+- `outputs/phase-12/system-spec-update-summary.md` — 11/07/12 系の追補点
+- `outputs/phase-12/documentation-changelog.md` — 本タスクで更新した doc 一覧
+- `outputs/phase-12/unassigned-task-detection.md` — admin の他機能（CSV / 統計 / 一括）など未割当の検出
+- `outputs/phase-12/skill-feedback-report.md` — task-specification-creator skill への feedback
+- `outputs/phase-12/phase12-task-spec-compliance-check.md` — 本仕様書の compliance 自己確認
+
+## 実行タスク
+
+1. 概念説明を中学生にも伝わる粒度で書く。完了条件: 上記 5 概念に例え話が紐付く。
+2. 6 種ドキュメントの placeholder を作る。完了条件: 各 path が決まる。
+3. 11-admin-management / 07-edit-delete / 12-search-tags への追補が必要かを判定する。完了条件: 追補要否が決まる。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/07-edit-delete.md
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 11 evidence
+- 下流: Phase 13 PR 作成
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 を doc 更新でも侵さない
+- secret 値が doc に転記されていない
+- 例え話に PII / 実会員情報が混ざらない
+
+## サブタスク管理
+
+- [ ] 5 概念の例え話を書く
+- [ ] 6 種 doc placeholder を作る
+- [ ] 追補要否判定を行う
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+- outputs/phase-12/implementation-guide.md
+- outputs/phase-12/system-spec-update-summary.md
+- outputs/phase-12/documentation-changelog.md
+- outputs/phase-12/unassigned-task-detection.md
+- outputs/phase-12/skill-feedback-report.md
+- outputs/phase-12/phase12-task-spec-compliance-check.md
+
+## 完了条件
+
+- 中学生レベル概念説明 + 日常例え話が 5 概念に対して書かれる
+- 6 種 doc が全部 placeholder 含めて存在する
+- 正本仕様への追補要否が記録される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、doc 同期結果と PR description 素材を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06c-B-admin-members/phase-13.md
@@ -1,0 +1,109 @@
+# Phase 13: PR 作成 — 06c-B-admin-members
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-B-admin-members |
+| phase | 13 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+| user_approval_required | true |
+
+## 目的
+
+仕様書のみを対象とした PR を作成するための最終ゲートを定義する。実装の PR ではない。
+
+## approval gate
+
+- 本タスクは spec のみ。**user の明示承認が無ければ commit / push / PR を作成しない。**
+- 実装 PR は本タスクの scope 外。実装担当者が別ブランチで進める。
+
+## change-summary（spec PR 用 placeholder）
+
+- 追加: `docs/30-workflows/02-application-implementation/06c-B-admin-members/` 配下 15 ファイル
+- 内容: 06c admin members の follow-up 仕様書（一覧/詳細/検索/論理削除/復元/ロール/audit）
+- 影響: docs only（コード変更なし）
+
+## local-check-result（実行時に置換）
+
+| 項目 | 結果 |
+| --- | --- |
+| `mise exec -- pnpm typecheck` | docs only のため対象外 |
+| `mise exec -- pnpm lint` | docs only のため対象外 |
+| markdown lint（あれば） | placeholder |
+| skill index drift | placeholder |
+
+## PR template（提案）
+
+```
+title: docs(06c-B): admin members follow-up spec
+
+## Summary
+- /admin/members 一覧・詳細の follow-up 仕様書 15 ファイルを追加
+- 11-admin-management.md / 07-edit-delete.md / 12-search-tags.md と整合
+- 不変条件 #4 / #5 / #11 / #13 を全 phase で参照
+
+## Test plan
+- [ ] 仕様書のみのため code test は対象外
+- [ ] 実装は本 PR の scope 外（後続 PR）
+- [ ] 08b admin members E2E / 09a admin smoke の前提が揃ったことを確認
+```
+
+## 実行タスク
+
+1. user 承認を得るまで commit / push / PR を作成しない。完了条件: 承認エビデンスがある。
+2. 承認後、change-summary を確定し PR description を組み立てる。完了条件: PR template が埋まる。
+3. PR 作成後、08b / 09a への引き渡しを記録する。完了条件: 後続タスクが開始可能。
+
+## 参照資料
+
+- 本仕様書 Phase 1〜12
+- CLAUDE.md ブランチ戦略
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-B-admin-members/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: Phase 12 ドキュメント更新
+- 下流: 08b admin members E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #4 / #5 / #11 / #13 を PR description でも侵さない
+- secret 値を PR 本文に書かない
+- 承認なしに自走しない
+
+## サブタスク管理
+
+- [ ] user 承認の確認
+- [ ] change-summary 確定
+- [ ] PR template 反映
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- user 承認後にのみ PR が作成される
+- change-summary が docs only であることを明示する
+- 後続タスクの開始条件が記録される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 承認なしに commit / push / PR を実行していない
+
+## 次タスクへの引き渡し
+
+08b admin members E2E と 09a admin staging smoke へ、本仕様書の AC / evidence path / blocker を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/artifacts.json
@@ -1,0 +1,174 @@
+{
+  "task_name": "06c-C-admin-tags",
+  "task_path": "docs/30-workflows/02-application-implementation/06c-C-admin-tags",
+  "wave": "06c-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "06c-admin-pages-body",
+    "07b-schema-ops-body",
+    "06b-A-me-api-authjs-session-resolver",
+    "06c-B-admin-members"
+  ],
+  "blocks": [
+    "06c-D-admin-schema",
+    "08b-admin-tags-e2e",
+    "09a-staging-admin-smoke"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "spec_created",
+    "docs_only": true,
+    "remaining_only": true,
+    "scope": "application_implementation",
+    "visualEvidence": "VISUAL_ON_EXECUTION"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-01/main.md"],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-02/main.md"],
+      "depends_on_phases": [1],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-03/main.md"],
+      "depends_on_phases": [2],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-04/main.md"],
+      "depends_on_phases": [3],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-05/main.md"],
+      "depends_on_phases": [4],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-06/main.md"],
+      "depends_on_phases": [5],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-07/main.md"],
+      "depends_on_phases": [6],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-08/main.md"],
+      "depends_on_phases": [7],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-09/main.md"],
+      "depends_on_phases": [8],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-10/main.md"],
+      "depends_on_phases": [9],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-11/main.md"],
+      "depends_on_phases": [10],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-12/main.md"],
+      "depends_on_phases": [11],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-13/main.md"],
+      "depends_on_phases": [12],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/00-getting-started-manual/specs/12-search-tags.md",
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md"
+  ],
+  "endpoints": [
+    "GET /api/admin/tags",
+    "POST /api/admin/tags",
+    "PATCH /api/admin/tags/:id",
+    "DELETE /api/admin/tags/:id",
+    "POST /api/admin/tags/:id/aliases",
+    "DELETE /api/admin/tags/:id/aliases",
+    "POST /api/admin/tags/:id/assignments",
+    "DELETE /api/admin/tags/:id/assignments"
+  ],
+  "d1_tables": [
+    "tags",
+    "tag_aliases",
+    "member_tags",
+    "admin_audit_log"
+  ],
+  "ui_routes": [
+    "/admin/tags"
+  ],
+  "secrets_introduced": [],
+  "invariants_touched": [5, 11, 13, 15],
+  "doc_references": [
+    "docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/index.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/index.md
@@ -1,0 +1,115 @@
+# 06c-C-admin-tags
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06c-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+管理者向けタグ管理画面 `/admin/tags` の実装 follow-up 仕様書。`12-search-tags.md` が定めるタグ正本と `11-admin-management.md` が定める admin タグ操作（タグ作成/編集/別名管理/メンバー割当）を、admin pages 本体（06c）と admin schema/tag ops 本体（07b）に乗せる形で確定させる。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、admin pages 本体（06c）と admin schema 本体（07b）の納品物において `/admin/tags` ルートと API 実装が別 wave に分離されている穴を埋める follow-up である。具体的には `claude-design-prototype/pages-admin.jsx` の tags section と `12-search-tags.md` `11-admin-management.md` の正本に対して、admin tags の CRUD UI / API / D1 操作 / audit log を一筆書きで設計する責務がどの本体タスクにも完全には乗っていないため、本タスクで spec のみを確定する。
+
+## scope in / out
+
+### Scope In
+- `/admin/tags` ルート（一覧 / 作成 / 編集 / 別名管理 / メンバー割当）の UI 仕様
+- API: `GET/POST /api/admin/tags`, `PATCH/DELETE /api/admin/tags/:id`, `POST/DELETE /api/admin/tags/:id/aliases`, `POST/DELETE /api/admin/tags/:id/assignments`
+- D1 tables: `tags`, `tag_aliases`, `member_tags` の admin 操作面
+- admin role boundary（不変条件 #5 / #11）と audit log（不変条件 #13）
+
+### Scope Out
+- 公開ディレクトリ側のタグ検索 UI
+- メンバー本人によるタグ申請 UI
+- Google Form 由来のタグ抽出ロジック変更
+- production secret 値の記録
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 06c-B-admin-members（admin shell 共通基盤）
+- 06c admin pages 本体（admin layout / nav / role guard）
+- 07b admin schema / tag ops 本体（D1 migration / repository 層）
+- 06b-A-me-api-authjs-session-resolver（admin session resolver の前提）
+
+### Blocks
+- 06c-D-admin-schema（admin shell 共通基盤を引き継ぐ）
+- 08b-A-playwright-e2e-full-execution（admin tags E2E）
+- 09a-A-staging-deploy-smoke-execution（admin staging smoke）
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06b-A → 06c admin pages → 07b admin schema → 06c-C** の serial。
+- 本タスクは admin tags の UI / API / D1 を貫通する SRP を担う。
+- 06c-A〜E（admin 5 件）は実態として admin shell 共通基盤を共有する parallel-eligible だが、命名規則「sort 順 = 実行順」に従い名目上 serial として A → B → C → D → E の順で実行する。
+
+## refs
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## AC
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log（actorId / action / targetTagId / timestamp）に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-01.md
@@ -1,0 +1,84 @@
+# Phase 1: 要件定義 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 1 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-02.md
@@ -1,0 +1,84 @@
+# Phase 2: 設計 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 2 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+admin tags の UI / API / D1 / 型 を Mermaid と表で固める。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-03.md
@@ -1,0 +1,84 @@
+# Phase 3: 設計レビュー — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 3 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+simpler alternative とのトレードオフを書き、PASS-MINOR-MAJOR を判定する。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-04.md
@@ -1,0 +1,84 @@
+# Phase 4: テスト戦略 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 4 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+unit / contract / E2E / authorization のテスト戦略を先に設計する。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-05.md
@@ -1,0 +1,84 @@
+# Phase 5: 実装ランブック — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 5 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実装手順を runbook 化し、コード placeholder と擬似コードで書く。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-06.md
@@ -1,0 +1,84 @@
+# Phase 6: 異常系検証 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 6 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+401 / 403 / 404 / 422 / 5xx / 重複 / 削除済み tag / audit log 失敗 を洗う。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-07.md
@@ -1,0 +1,84 @@
+# Phase 7: AC マトリクス — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 7 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+AC matrix を作り、Phase 1 AC と Phase 4 検証を一対一対応させる。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-08.md
@@ -1,0 +1,84 @@
+# Phase 8: DRY 化 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 8 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+型・命名・path / endpoint / module 名を DRY 化する。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-09.md
@@ -1,0 +1,84 @@
+# Phase 9: 品質保証 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 9 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+型安全 / lint / test / a11y・無料枠・secret hygiene を確認する。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-10.md
@@ -1,0 +1,84 @@
+# Phase 10: 最終レビュー — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 10 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+GO/NO-GO を出す。依存先 wave の AC が満たされていなければ NO-GO。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-11.md
@@ -1,0 +1,84 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 11 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+manual smoke の手順を書き、admin tags UI / 認可 / audit log を人が確認できるようにする。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-12.md
@@ -1,0 +1,98 @@
+# Phase 12: ドキュメント更新 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 12 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 中学生レベル概念説明
+
+このタスクで扱う「admin タグ管理」は、図書館の本にシールを貼って整理する仕事に似ている。タグはシール、メンバーは本、別名は同じシールに付く別の呼び方（たとえば「料理」と「クッキング」は同じシール）にあたる。管理者だけがシールを増やしたり貼り替えたりできて、他の人は触れない。
+
+### 日常の例え話
+
+- **タグ作成**: 図書館の司書さんが新しいジャンルのシールを作る。中身が同じシールが既にあるなら作り直さない（重複 422）。
+- **別名（alias）**: 同じシールを「料理」と呼ぶ人と「クッキング」と呼ぶ人がいるので、両方の呼び方を 1 枚のシールに紐づけておく。検索のときどちらでヒットしても同じ棚にたどり着ける。
+- **メンバー割当**: 本にシールを貼る作業。同じ本に同じシールを 2 回貼っても結果は変わらない（冪等）。
+- **audit log**: 司書さんが「いつ・誰が・どの本に・どのシールを貼った/はがした」をノートに書き残す。あとで誰かが「勝手に貼られた」と言い出したときの証拠になる。
+- **admin boundary**: シールの棚に入れるのは司書さんだけ。一般来館者が入ろうとしたら鍵が閉まっている（403）。
+
+この比喩で `/admin/tags` の責務は「シール製造 + 貼付作業 + 作業ノート」の 3 つに分かれることがわかる。本仕様書はその 3 つが UI / API / D1 のどこに乗るかを確定させる。
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06c-C-admin-tags/phase-13.md
@@ -1,0 +1,84 @@
+# Phase 13: PR 作成 — 06c-C-admin-tags
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-C-admin-tags |
+| phase | 13 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+承認後のみ PR を作る（feature/* → dev → main）。
+
+## 実行タスク
+
+1. 参照資料と該当 specs を確認する。完了条件: admin tags の正本境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/(routes)/
+- apps/api/src/routes/admin/
+- packages/shared/src/admin/tags.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-C-admin-tags/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b admin schema / tag ops 本体, 06b-followup-002 session resolver
+- 下流: 08b admin tags E2E, 09a admin staging smoke
+
+## 多角的チェック観点
+
+- #5 apps/web D1 direct access forbidden
+- #11 admin 編集境界
+- #13 audit log
+- #15 Auth session boundary
+- 未実装/未実測を PASS と扱わない。
+- 公開 tag 検索面と admin tag 編集面の責務を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- 管理者は `/admin/tags` でタグ一覧・作成・編集・削除・別名追加・メンバー割当ができる
+- 非管理者は 403 を受け、admin route に到達できない
+- タグ名 / 別名は重複登録できず、422 を返す
+- メンバー割当は memberId に対して冪等で、再割当は 200 を返す
+- すべての admin タグ操作は audit log に記録される
+- D1 への直接アクセスは `apps/api` に閉じ、`apps/web` は cookie forwarding のまま成立する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+本タスクの完了。後続 follow-up や本体タスクへ AC 達成状況を引き渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/artifacts.json
@@ -1,0 +1,169 @@
+{
+  "task_name": "06c-D-admin-schema",
+  "task_path": "docs/30-workflows/02-application-implementation/06c-D-admin-schema",
+  "wave": "06c-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "06c-C-admin-tags",
+    "06c-admin-pages-body",
+    "07b-schema-ops-body",
+    "06b-A-me-api-authjs-session-resolver",
+    "forms-api-integration"
+  ],
+  "blocks": [
+    "06c-E-admin-meetings",
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution",
+    "forms-drift-detection"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "spec_created",
+    "docs_only": true,
+    "remaining_only": true,
+    "scope": "application_implementation",
+    "visualEvidence": "VISUAL_ON_EXECUTION"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-01/main.md"],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-02/main.md"],
+      "depends_on_phases": [1],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-03/main.md"],
+      "depends_on_phases": [2],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-04/main.md"],
+      "depends_on_phases": [3],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-05/main.md"],
+      "depends_on_phases": [4],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-06/main.md"],
+      "depends_on_phases": [5],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-07/main.md"],
+      "depends_on_phases": [6],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-08/main.md"],
+      "depends_on_phases": [7],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-09/main.md"],
+      "depends_on_phases": [8],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-10/main.md"],
+      "depends_on_phases": [9],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-11/main.md"],
+      "depends_on_phases": [10],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-12/main.md"],
+      "depends_on_phases": [11],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-13/main.md"],
+      "depends_on_phases": [12],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/01-api-schema.md",
+    "docs/00-getting-started-manual/specs/03-data-fetching.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md"
+  ],
+  "endpoints": [
+    "GET /api/admin/schema/aliases",
+    "POST /api/admin/schema/aliases",
+    "POST /api/admin/schema/resync"
+  ],
+  "d1_tables": [
+    "schema_alias",
+    "schema_alias_audit"
+  ],
+  "ui_routes": [
+    "/admin/schema"
+  ],
+  "secrets_introduced": [],
+  "invariants_touched": [1, 2, 3, 4, 5, 13],
+  "doc_references": [
+    "docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/index.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/index.md
@@ -1,0 +1,133 @@
+# 06c-D-admin-schema
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06c-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+`/admin/schema` を実装し、Google Forms の questionId と internal field の alias mapping を admin が安全に保守・再 sync できる UI / API を成立させる。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、`11-admin-management.md` の admin schema management セクションが指す「schema alias assignment 画面」が、06c admin pages 本体・07b schema ops 本体のどちらにも closed gate として接続されていない follow-up gap だけを扱う。Forms schema の正本（`01-api-schema.md`）と Forms sync（`03-data-fetching.md`）の橋渡しを admin UI に閉じる責務に限定する。
+
+## scope in / out
+
+### Scope In
+- `/admin/schema` ルート（admin 専用 UI）の page / loader / action 仕様
+- 現行 alias mapping 一覧（questionId × internal field alias × source section × last-synced-at）
+- 未マップ questionId のハイライトと未同意 mapping の警告
+- 新規 alias 作成・既存 alias 編集・削除の UI flow と監査ログ
+- mapping 変更履歴の表示（admin-managed data 側に保存）
+- 手動 Forms re-sync trigger（read-only sync）
+- `GET /api/admin/schema/aliases` `POST /api/admin/schema/aliases` `POST /api/admin/schema/resync`
+- admin 認可境界の test と Forms drift 検知の前提整備
+
+### Scope Out
+- Forms schema 自体の固定（不変条件 #1 違反）
+- consent キー名の変更（不変条件 #2 違反）
+- `responseEmail` を Form 項目として再導入する変更（不変条件 #3 違反）
+- 一般会員向け UI の変更
+- D1 schema 自体の migration（07b 本体に閉じる）
+- secret 値・実 questionId の本仕様への記録
+- 未承認の commit / push / PR
+
+## dependencies
+
+### Depends On
+- 06c-C-admin-tags（admin shell 共通基盤）
+- 06c admin pages 本体（admin shell・nav・auth gate）
+- 07b schema ops 本体（admin-managed data の schema_alias テーブル）
+- 06b-A-me-api-authjs-session-resolver（admin session resolver の前提）
+- Forms API integration（`03-data-fetching.md` の sync runner）
+
+### Blocks
+- 06c-E-admin-meetings（admin shell 共通基盤を引き継ぐ）
+- 08b-A-playwright-e2e-full-execution（admin schema E2E）
+- 09a-A-staging-deploy-smoke-execution（staging admin smoke）
+- Forms drift 検知（運用 alert）
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06c 本体 → 07b 本体 → 本タスク → 08b-A E2E** の serial。
+- 本タスクは admin schema 管理 UI / API の単独 SRP を担い、後続 E2E / smoke の前提条件を確定する。
+- 06c-A〜E（admin 5 件）は実態として admin shell 共通基盤を共有する parallel-eligible だが、命名規則「sort 順 = 実行順」に従い名目上 serial として A → B → C → D → E の順で実行する。
+
+## refs
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+- apps/api/src/middleware/require-admin.ts
+
+## AC
+
+- `/admin/schema` が admin session で 200 を返し、未認可は 401 / 403 を返す
+- alias mapping 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が画面上で識別可能にハイライトされる
+- 新規 alias 作成・編集・削除が `POST /api/admin/schema/aliases` 経由で永続化され、変更履歴が記録される
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き、差分 questionId を返す
+- Forms schema をコードに固定せず、admin-managed data として alias を分離保持できる
+- consent キー（`publicConsent` / `rulesConsent`）と `responseEmail` system field は alias 編集対象外として保護される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## services / secrets
+
+- Cloudflare Workers (`apps/web` admin shell, `apps/api` admin route)
+- Cloudflare D1（admin-managed data: schema_alias / schema_alias_audit）
+- Google Forms API（read-only sync）
+- secret: `AUTH_SECRET` / `GOOGLE_FORMS_API_KEY`（参照のみ・本仕様には実値を記録しない）
+
+## invariants touched
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キーは `publicConsent` / `rulesConsent` に統一
+- #3 `responseEmail` は system field として扱う
+- #4 Google Form schema 外のデータは admin-managed data として分離
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 監査ログ（admin 操作）
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-01.md
@@ -1,0 +1,85 @@
+# Phase 1: 要件定義 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 1 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。`/admin/schema` が解く true issue（Forms questionId と internal field alias の安全な mapping 保守）を 4 条件（価値性・実現性・整合性・運用性）で固定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-02.md
@@ -1,0 +1,85 @@
+# Phase 2: 設計 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 2 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+最小責務で `/admin/schema` の component / module / endpoint / D1 table / 型を Mermaid と表で固める。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-03.md
@@ -1,0 +1,85 @@
+# Phase 3: 設計レビュー — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 3 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューし、simpler alternative とのトレードオフを PASS-MINOR-MAJOR で判定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-04.md
@@ -1,0 +1,85 @@
+# Phase 4: テスト戦略 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 4 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+自動（unit / contract / E2E / authorization）と手動・外部環境検証の境界を `/admin/schema` 仕様に合わせて定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-05.md
@@ -1,0 +1,85 @@
+# Phase 5: 実装ランブック — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 5 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+`/admin/schema` の page / loader / action と admin route の実装手順を runbook + placeholder + 擬似コードで定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-06.md
@@ -1,0 +1,85 @@
+# Phase 6: 異常系検証 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 6 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+401 / 403 / 404 / 422 / 5xx / Forms sync 失敗 / 未マップ questionId / 重複 alias / consent key 編集試行などの失敗時挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-07.md
@@ -1,0 +1,85 @@
+# Phase 7: AC マトリクス — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 7 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+Phase 1 AC × Phase 4 検証 × Phase 5 実装 を一対一に対応付け、evidence path を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-08.md
@@ -1,0 +1,85 @@
+# Phase 8: DRY 化 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 8 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+型・命名・path・endpoint・module 名を DRY 化する（schema_alias / SchemaAliasDto / `/api/admin/schema/*` 命名整合）。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-09.md
@@ -1,0 +1,85 @@
+# Phase 9: 品質保証 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 9 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+型安全 / lint / test / a11y / 無料枠 / secret hygiene を確認する。Forms API quota の見積もりを含む。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-10.md
@@ -1,0 +1,85 @@
+# Phase 10: 最終レビュー — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 10 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+依存先 wave の AC を確認し GO/NO-GO を出す。blocker 一覧を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-11.md
@@ -1,0 +1,85 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 11 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+`/admin/schema` の admin login → alias 一覧 → 新規作成 → resync → 監査履歴 を visual evidence 付きで実測する手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-12.md
@@ -1,0 +1,101 @@
+# Phase 12: ドキュメント更新 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 12 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。Phase 12 は中学生レベル概念説明を含む。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## 中学生レベル概念説明（Phase 12 必須）
+
+- 「Google Form の質問」と「データベースの欄の名前」は別の言葉でつけられている。たとえばフォームでは `question_07f3` という機械的な ID で呼ばれているけど、データベースでは `phoneNumber` という人が読みやすい名前で持ちたい。この 2 つを「これは同じ意味だよ」と結びつける表が alias mapping。
+- `/admin/schema` 画面は、その対応表を管理者だけが安全に編集できる場所。フォームに新しい質問が増えたら、ここに来て「この質問はこの名前に対応するよ」とつなげる作業をする。
+- 「同意のチェック」と「メールアドレス」は仕組みの根っこなので、ここでは編集できないように鍵をかけてある。間違えて壊すと全員のログインや同意確認が動かなくなるから。
+- 「再同期ボタン」は、フォームの中身を Google から取り直してくる動作。1 回押すと 1 回だけ取りに行く（連打しても無料枠を食いつぶさない設計）。
+
+## ドキュメント同期成果物（Phase 12 必須）
+
+- outputs/phase-12/implementation-guide.md
+- outputs/phase-12/system-spec-update-summary.md
+- outputs/phase-12/documentation-changelog.md
+- outputs/phase-12/unassigned-task-detection.md
+- outputs/phase-12/skill-feedback-report.md
+- outputs/phase-12/phase12-task-spec-compliance-check.md
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06c-D-admin-schema/phase-13.md
@@ -1,0 +1,85 @@
+# Phase 13: PR 作成 — 06c-D-admin-schema
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-D-admin-schema |
+| phase | 13 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+ユーザー承認後の PR 作成条件だけを定義する。feature/* → dev → main の経路を維持する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: schema mapping 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/web/app/admin/schema/page.tsx（spec target）
+- apps/api/src/routes/admin/schema/index.ts（spec target）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-D-admin-schema/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 07b schema ops 本体, 06b-followup-002 session resolver, Forms API integration
+- 下流: 08b admin schema E2E, 09a staging admin smoke, Forms drift 検知
+
+## 多角的チェック観点
+
+- #1 実フォーム schema をコードに固定しすぎない
+- #2 consent キー（`publicConsent` / `rulesConsent`）を alias 編集対象外として保護
+- #3 `responseEmail` system field を alias 編集対象外として保護
+- #4 admin-managed data 分離（schema_alias / schema_alias_audit）
+- #5 D1 直接アクセスは `apps/api` に閉じる
+- #13 admin 操作の監査ログ
+- 未実装/未実測を PASS と扱わない。
+- admin 認可境界（401 / 403）と一般会員 UI を混同しない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- `/admin/schema` が admin session で 200、未認可で 401 / 403 を返す
+- alias 一覧に questionId / internal field / source section / last-synced-at が表示される
+- 未マップ questionId が UI 上で識別可能にハイライトされる
+- 新規・編集・削除が `POST /api/admin/schema/aliases` で永続化され audit 履歴が残る
+- `POST /api/admin/schema/resync` が Forms API を 1 回叩き差分 questionId を返す
+- consent キーと `responseEmail` system field は alias 編集対象外として保護される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/artifacts.json
@@ -1,0 +1,171 @@
+{
+  "task_name": "06c-E-admin-meetings",
+  "task_path": "docs/30-workflows/02-application-implementation/06c-E-admin-meetings",
+  "wave": "06c-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "06c-D-admin-schema",
+    "06c-admin-pages-shell",
+    "06b-A-me-api-authjs-session-resolver"
+  ],
+  "blocks": [
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "spec_created",
+    "docs_only": true,
+    "remaining_only": true,
+    "scope": "application_implementation",
+    "visualEvidence": "VISUAL_ON_EXECUTION"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-01/main.md"],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-02/main.md"],
+      "depends_on_phases": [1],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-03/main.md"],
+      "depends_on_phases": [2],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-04/main.md"],
+      "depends_on_phases": [3],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-05/main.md"],
+      "depends_on_phases": [4],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-06/main.md"],
+      "depends_on_phases": [5],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-07/main.md"],
+      "depends_on_phases": [6],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-08/main.md"],
+      "depends_on_phases": [7],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-09/main.md"],
+      "depends_on_phases": [8],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-10/main.md"],
+      "depends_on_phases": [9],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-11/main.md"],
+      "depends_on_phases": [10],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-12/main.md"],
+      "depends_on_phases": [11],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": ["outputs/phase-13/main.md"],
+      "depends_on_phases": [12],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/00-getting-started-manual/specs/11-admin-management.md",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/06-member-auth.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/specs/13-mvp-auth.md"
+  ],
+  "endpoints": [
+    "GET /api/admin/meetings",
+    "POST /api/admin/meetings",
+    "PATCH /api/admin/meetings/:id",
+    "POST /api/admin/meetings/:id/attendances",
+    "GET /api/admin/meetings/:id/export.csv"
+  ],
+  "d1_tables": [
+    "meetings",
+    "meeting_attendances"
+  ],
+  "ui_routes": [
+    "/admin/meetings"
+  ],
+  "secrets_introduced": [],
+  "invariants_touched": [4, 5, 7, 13, 15],
+  "doc_references": [
+    "docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx",
+    "apps/api/src/middleware/require-admin.ts",
+    "apps/web/middleware.ts",
+    "apps/api/src/index.ts"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/index.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/index.md
@@ -1,0 +1,135 @@
+# 06c-E-admin-meetings
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 06c-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+管理者向け `/admin/meetings` 画面と `/api/admin/meetings*` の最小実装 follow-up を仕様化する。支部会の開催日と参加履歴を Google Form schema 外の admin-managed data として登録・編集・CSV export できるよう、UI と API、D1 テーブル設計を確定する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、`11-admin-management.md` で `/admin/meetings` の存在は規定済みだが、開催日 (`meetings`) と参加履歴 (`meeting_attendances`) の D1 schema、API endpoint、UI 構成が follow-up gate として未確定なまま 06c admin pages 本体タスクで `/admin/members` `/admin/tags` `/admin/schema` のみ閉じられたため、残存する meetings 機能だけを切り出して実装仕様書化する。
+
+## scope in / out
+
+### Scope In
+- D1 tables `meetings` / `meeting_attendances` の schema 定義（admin-managed data 分離）
+- `apps/api` `/api/admin/meetings`（GET 一覧、POST 作成）
+- `apps/api` `/api/admin/meetings/:id`（PATCH 更新）
+- `apps/api` `/api/admin/meetings/:id/attendances`（POST 参加メンバー記録 / 解除）
+- `apps/api` `/api/admin/meetings/:id/export.csv`（CSV export）
+- `apps/web` `/admin/meetings` 画面（一覧 / 作成 / 編集 / 参加記録 / CSV ダウンロード）
+- `requireAdmin` middleware 適用（API gate 第2段）
+- `apps/web/middleware.ts` `/admin/:path*` matcher への合流（UI gate 第1段）
+- audit log entry（meetings.create / update / attendance.add / attendance.remove）
+
+### Scope Out
+- 開催日に紐づく決済 / 会費連動
+- 出欠の本人セルフ申告 UI（管理者操作のみ）
+- Google Form 同期対象への昇格（admin-managed 分離維持）
+- 物理削除（論理削除のみ、`deletedAt` で表現）
+- meetings の自動繰り返しルール（cron 生成等）
+- production secret 値の記録
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 06c-D-admin-schema（admin shell 共通基盤）
+- 06c admin pages 本体（`/admin` shell、admin layout、左 nav）
+- 06b-A-me-api-authjs-session-resolver（session resolver の本番接続）
+- `apps/api/src/middleware/require-admin.ts`（API gate 第2段）
+- `apps/web/middleware.ts` の `/admin/:path*` matcher
+- D1 binding（apps/api の `DB`）
+- `11-admin-management.md` `/admin/meetings` 規定
+
+### Blocks
+- 08b-A-playwright-e2e-full-execution（admin meetings E2E）
+- 09a-A-staging-deploy-smoke-execution（staging admin smoke）
+
+### 内部依存（同 wave 内 serial 実行を明示）
+- 表記上は parallel だが、実依存は **06b-A → 06c admin shell → 06c-E** の serial。
+- 本タスクは meetings 単独 SRP を担い、08b-A / 09a-A の前提条件を確定する。
+- 06c-A〜E（admin 5 件）は実態として admin shell 共通基盤を共有する parallel-eligible だが、命名規則「sort 順 = 実行順」に従い名目上 serial として A → B → C → D → E の順で実行する。
+
+## refs
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/middleware.ts
+- apps/api/src/index.ts
+
+## AC
+
+- `/admin/meetings` が admin session で 200 を返し、未ログイン / 非 admin は `/login?gate=admin_required` または 403 になる
+- `POST /api/admin/meetings` が `{ heldOn, title, location?, note? }` を受け取り `meetings` 行を作成する
+- `PATCH /api/admin/meetings/:id` が title / location / note / heldOn / deletedAt を更新できる
+- `POST /api/admin/meetings/:id/attendances` が `{ memberId, attended }` を受け取り `meeting_attendances` を upsert する
+- `GET /api/admin/meetings/:id/export.csv` が `meetingId, heldOn, memberId, displayName, attended` を含む CSV を返す
+- `meetings` / `meeting_attendances` は Google Form 同期対象にならない（admin-managed 分離）
+- 全 mutation が audit log に記録される
+- apps/web は D1 を直参照せず、cookie forwarding で `apps/api` を呼ぶ
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## services / secrets
+
+- Cloudflare Workers（apps/api / apps/web）
+- Cloudflare D1（`DB` binding、tables: `meetings`, `meeting_attendances`）
+- AUTH_SECRET（既存、追加発行なし）
+- 本タスクは新規 secret を導入しない
+
+## invariants touched
+
+- #4 admin-managed data 分離（meetings は Form schema 外）
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #13 audit log
+- #15 Auth session boundary（admin gate 二段防御）
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、D1 migration 適用、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-01.md
@@ -1,0 +1,82 @@
+# Phase 1: 要件定義 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 1 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+`/admin/meetings` 機能の真の責務、scope、依存境界、成功条件を確定する。Form schema 外の admin-managed data として扱う原則を固定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: meetings の責務境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/06-member-auth.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver, requireAdmin middleware
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離（Form schema に昇格しない）
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #13 audit log
+- #15 Auth session boundary（admin gate 二段防御）
+- 未実装/未実測を PASS と扱わない。
+- gas-prototype の挙動を本番仕様に昇格させない。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- `/admin/meetings` が admin session で 200 を返し、未ログイン / 非 admin は 403 になる
+- `meetings` / `meeting_attendances` の D1 schema 案が確定する
+- API endpoint と HTTP メソッドが確定する
+- apps/web は cookie forwarding のみで成立する
+- 全 mutation が audit log 対象であることが明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate、D1 schema 案を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-02.md
@@ -1,0 +1,81 @@
+# Phase 2: 設計 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 2 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+`/admin/meetings` の module 構造、D1 schema、API contract、UI コンポーネント分割を最小責務で確定する。
+
+## 実行タスク
+
+1. D1 tables `meetings` / `meeting_attendances` の列・index・FK 制約を設計する。完了条件: schema が `08-free-database.md` の方針と整合する。
+2. `apps/api` route handler の入出力 schema（zod）と `requireAdmin` mount 位置を設計する。完了条件: 5 endpoint が一覧化される。
+3. `apps/web` `/admin/meetings` の Drawer / Form / Table 構成を設計する。完了条件: cookie forwarding のみで API を叩く。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+- apps/web/middleware.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+- Mermaid 構造図 / dependency matrix / module 設計を outputs/phase-02/main.md に記録する。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver, requireAdmin middleware
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離（Form schema に昇格しない）
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #13 audit log
+- #15 Auth session boundary
+- 無料枠（D1 row 数 / Workers CPU 時間）を超過しない設計。
+
+## サブタスク管理
+
+- [ ] D1 schema を確定する
+- [ ] API contract（zod）を確定する
+- [ ] UI コンポーネント分割を確定する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- `meetings` / `meeting_attendances` の DDL 案が固まる
+- 5 endpoint の request/response schema が確定する
+- apps/web の cookie forwarding 経路が確定する
+- 全 mutation が audit log 出力点と紐づく
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、設計案、依存矩陣、module 配置を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-03.md
@@ -1,0 +1,75 @@
+# Phase 3: 設計レビュー — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 3 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+Phase 2 設計に対する simpler alternative を 3 案以上挙げ、PASS-MINOR-MAJOR を判定する。
+
+## 実行タスク
+
+1. alternative 案を 3 案以上書く（例: KV で代替 / meetings を Form schema に同居 / attendances を JSON 列に集約）。完了条件: 各案のトレードオフが明文化される。
+2. 不変条件 #4/#5/#13/#15 違反の有無を確認する。完了条件: 違反案は MAJOR で却下される。
+3. 採用案を確定する。完了条件: PASS-MINOR-MAJOR が記録される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- outputs/phase-02/main.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- alternative 案で無料枠 / 運用負荷が悪化していないか。
+
+## サブタスク管理
+
+- [ ] alternative 3 案を書く
+- [ ] PASS-MINOR-MAJOR を判定する
+- [ ] 採用案を確定する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- 採用案が PASS で確定する
+- 不採用案の MAJOR 理由が明記される
+- 不変条件違反がないことが確認される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、確定設計とレビュー結果を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-04.md
@@ -1,0 +1,77 @@
+# Phase 4: テスト戦略 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 4 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+unit / contract / E2E / authorization の verify suite を実装前に固定する。
+
+## 実行タスク
+
+1. unit: meetings repository / attendances upsert / CSV serializer のテスト観点を列挙する。完了条件: 5 endpoint の正常系・境界系が網羅される。
+2. contract: zod schema と API request/response の一致を契約テストで検証する。完了条件: `apps/api/test/admin/meetings.spec.ts` 想定の test ID が記録される。
+3. E2E（Playwright）: admin login → 開催日作成 → 参加記録 → CSV 取得の流れを設計する。完了条件: 08b で実行可能なシナリオに落ちる。
+4. authorization: 未ログイン / 非 admin / `x-ubm-dev-session` の挙動を仕様化する。完了条件: 401 / 403 境界が確定する。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- apps/api/src/middleware/require-admin.ts
+- apps/web/middleware.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- a11y（Drawer / Form のキーボード操作）。
+
+## サブタスク管理
+
+- [ ] unit 観点を列挙する
+- [ ] contract 観点を列挙する
+- [ ] E2E シナリオを書く
+- [ ] authorization 境界を確定する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- 5 endpoint と UI の verify suite が確定する
+- 401 / 403 / 404 / 422 の境界が記録される
+- E2E シナリオが 08b で実行可能な粒度になる
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、verify suite と境界仕様を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-05.md
@@ -1,0 +1,79 @@
+# Phase 5: 実装ランブック — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 5 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実装手順を runbook + placeholder + 擬似コードで確定する。コードはこの仕様では書かない。
+
+## 実行タスク
+
+1. D1 migration `apps/api/migrations/00XX_meetings.sql` の追加手順を書く。完了条件: 列・index・FK が記載される。
+2. `apps/api/src/routes/admin/meetings.ts` の擬似コード（route handler / requireAdmin mount / zod schema / audit log emit）を書く。完了条件: 5 endpoint が placeholder で揃う。
+3. `apps/web/app/admin/meetings/page.tsx` の擬似コード（SSR fetch / Drawer / Form / Table / CSV download）を書く。完了条件: cookie forwarding のみが使われる。
+4. sanity check（`pnpm typecheck` / `pnpm lint` / `pnpm test --filter @repo/api`）を列挙する。完了条件: コマンドが mise exec 経由で記録される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/08-free-database.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-admin.jsx
+- apps/api/src/middleware/require-admin.ts
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+- 実装担当は本 phase の runbook を上から順に踏む。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #7 memberId/responseId separation
+- #13 audit log
+- #15 Auth session boundary
+
+## サブタスク管理
+
+- [ ] D1 migration runbook を書く
+- [ ] api route handler placeholder を書く
+- [ ] web page placeholder を書く
+- [ ] sanity check 一覧を書く
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- 実装担当が runbook を見て手戻りなく進められる粒度
+- placeholder と擬似コードがコンパイル可能な構造で書かれる
+- sanity check が `mise exec --` 経由で記載される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、runbook と placeholder を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-06.md
@@ -1,0 +1,77 @@
+# Phase 6: 異常系検証 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 6 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+401 / 403 / 404 / 409 / 422 / 5xx と削除済み member の取り扱い、attendance upsert の冪等性、CSV escape を網羅する。
+
+## 実行タスク
+
+1. 401（未ログイン）/ 403（非 admin）/ 404（meetingId 不在）の挙動を確定する。完了条件: API gate と UI gate の両方で記録される。
+2. 422（zod 検証失敗: heldOn 形式不正、memberId 存在せず）の挙動を確定する。完了条件: error response shape が固定される。
+3. 409（同 heldOn + 同 title 重複）/ attendance upsert の冪等性を確定する。完了条件: PRIMARY KEY (meetingId, memberId) で represent される。
+4. CSV escape（カンマ・改行・引用符を含む displayName）の挙動を確定する。完了条件: RFC 4180 準拠が確認される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log（失敗時も記録するか方針確定）
+- #15 Auth session boundary
+- 削除済み member への attendance 付与は 410 を返す。
+
+## サブタスク管理
+
+- [ ] 401/403/404 を確定する
+- [ ] 422 を確定する
+- [ ] 409 / 冪等性を確定する
+- [ ] CSV escape を確定する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- 全 failure case が response shape 付きで記録される
+- 冪等性 / RFC 4180 が AC 化される
+- audit log の失敗系ポリシーが固定される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、failure case と response shape を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-07.md
@@ -1,0 +1,74 @@
+# Phase 7: AC マトリクス — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 7 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+Phase 1 の AC × Phase 4 の verify × Phase 5 の実装 placeholder を一対一で対応付ける。
+
+## 実行タスク
+
+1. AC を行、検証手段を列とする matrix を作る。完了条件: 各 AC に少なくとも 1 つの verify が紐づく。
+2. 未紐付きの AC / 未使用の verify を 0 にする。完了条件: 孤立行・孤立列が無い。
+3. Phase 6 の failure case を AC として吸収する。完了条件: 401/403/404/409/422 が matrix に載る。
+
+## 参照資料
+
+- outputs/phase-01/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- AC が定量的（HTTP code / row 数 / column 順）に書かれているか。
+
+## サブタスク管理
+
+- [ ] AC × verify matrix を作る
+- [ ] 孤立行 / 孤立列を 0 にする
+- [ ] failure case を吸収する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- AC matrix が完成し、全行・全列に対応がある
+- failure case が AC として残らず吸収される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC matrix を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-08.md
@@ -1,0 +1,73 @@
+# Phase 8: DRY 化 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 8 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+命名・型・path・endpoint の重複を排し、Before / After で記録する。
+
+## 実行タスク
+
+1. endpoint 命名（`/api/admin/meetings`）を他 admin endpoint と整合させる。完了条件: kebab-case / 単数複数の規約が他 admin route と一致する。
+2. zod schema の `MeetingSchema` / `AttendanceSchema` を `packages/shared` に置くか api 内に置くかを判断する。完了条件: 重複が無い。
+3. CSV serializer を共通 util にできるか検討する。完了条件: Before / After で diff が記述される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- packages/shared/src/
+- apps/api/src/routes/admin/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- DRY と早すぎる抽象化のトレードオフ。
+
+## サブタスク管理
+
+- [ ] endpoint 命名を確認する
+- [ ] zod schema 配置を確定する
+- [ ] CSV serializer の共通化を検討する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- 命名・型・path・endpoint の Before / After が記録される
+- 早すぎる抽象化が回避される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、Before / After 表を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 9 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+型安全 / lint / test / a11y / 無料枠 / secret hygiene を確認する。
+
+## 実行タスク
+
+1. 型安全（`mise exec -- pnpm typecheck`）/ lint / test の通過条件を列挙する。完了条件: コマンドが記録される。
+2. 無料枠見積もり（D1 row 数: meetings 〜数百行 / attendances 〜数千行 / 月次 read 数）を出す。完了条件: 数値根拠が出る。
+3. secret hygiene（新規 secret 無し、AUTH_SECRET 流用、`.env` 平文禁止）を確認する。完了条件: チェックリストが埋まる。
+4. a11y（Drawer focus trap / Form label / CSV download button の aria）を確認する。完了条件: WCAG AA 観点が記録される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/08-free-database.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- CLAUDE.md（シークレット管理セクション）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+- secret 値そのものは記載しない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- 無料枠超過リスク（D1 row 数 / 月次 R/W）。
+
+## サブタスク管理
+
+- [ ] 型 / lint / test 通過条件を書く
+- [ ] 無料枠見積もりを書く
+- [ ] secret hygiene を確認する
+- [ ] a11y を確認する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- 型安全 / lint / test の green 条件が固定される
+- 無料枠が超過しないことが定量的に示される
+- 新規 secret が導入されないことが確認される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、品質チェックリストを渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-10.md
@@ -1,0 +1,72 @@
+# Phase 10: 最終レビュー — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 10 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+GO/NO-GO を判定し、blocker 一覧を確定する。
+
+## 実行タスク
+
+1. 上流 wave（06c admin shell / 06b-A session resolver）の AC が満たされているか確認する。完了条件: 未充足なら NO-GO。
+2. blocker 一覧（未確定 schema、未確定 endpoint、未確定 audit log policy 等）を出す。完了条件: 全 blocker に owner と期日案が付く。
+3. GO 判定の前提条件（user approval gate / staging deploy 順序）を明文化する。完了条件: Phase 13 の前提が固まる。
+
+## 参照資料
+
+- outputs/phase-01/main.md 〜 outputs/phase-09/main.md
+- 06b-A-me-api-authjs-session-resolver/index.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- 上流 NO-GO 状況を見落とさない。
+
+## サブタスク管理
+
+- [ ] 上流 AC を確認する
+- [ ] blocker 一覧を出す
+- [ ] GO/NO-GO を記録する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- GO/NO-GO 判定が記録される
+- blocker と owner / 期日が確定する
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、GO 判定と blocker 一覧を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-11.md
@@ -1,0 +1,80 @@
+# Phase 11: 手動 smoke / 実測 evidence — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 11 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実装後に踏む手動 smoke と実測 evidence の取得手順、placeholder 配置を確定する。
+
+## 実行タスク
+
+1. screenshot path を決める（`outputs/phase-11/screenshots/admin-meetings-list.png` など）。完了条件: list / create drawer / attendance / CSV のうち最低 4 枚が定義される。
+2. curl による API smoke 手順を書く（cookie 取得 → POST → GET → CSV download）。完了条件: 認証 cookie の扱いが明記される。
+3. wrangler 出力 placeholder（`bash scripts/cf.sh deploy --config apps/api/wrangler.toml --env staging` の Version ID 記録欄）を置く。完了条件: secret 値は記載しない。
+4. ログイン admin として Cloudflare staging で踏む手順を書く。完了条件: 失敗時の rollback 手順が併記される。
+
+## 参照資料
+
+- CLAUDE.md（Cloudflare 系 CLI 実行ルール）
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+- 実測時は `bash scripts/cf.sh ...` 経由のみ使用する（`wrangler` 直接実行禁止）。
+- screenshot / curl 出力 / wrangler 出力に secret 値が混入しないよう mask する。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- secret 値（API token / cookie 値）を成果物に含めない。
+
+## サブタスク管理
+
+- [ ] screenshot path を定義する
+- [ ] curl smoke 手順を書く
+- [ ] wrangler placeholder を置く
+- [ ] rollback 手順を書く
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+- outputs/phase-11/screenshots/（実測時に保存）
+- outputs/phase-11/curl/（実測時に保存）
+
+## 完了条件
+
+- 手動 smoke が再現可能な粒度で記述される
+- evidence path が AC matrix と一対一になる
+- secret 値が成果物に含まれない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、smoke 手順と evidence path を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-12.md
@@ -1,0 +1,105 @@
+# Phase 12: ドキュメント更新 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 12 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+正本仕様、runbook、lessons learned、未割当タスク、skill feedback の同期を定義する。実装担当が「次に同じ機能を作る人」に向けて中学生でも分かる言葉で説明できる状態を作る。
+
+## このタスクは何をやっているのか（中学生レベルの説明）
+
+`/admin/meetings` は「UBM 兵庫支部会の管理者が、いつ・どこで集まりがあったか、誰が来たかをパソコンから記録して、あとで Excel で見られるように CSV として書き出せる画面」を作るタスクです。
+
+会員さんの自己紹介（プロフィール）は Google フォームに本人が書いた内容を正解とするけれど、「集まりの開催日」と「誰が来たか」はフォームには書かれていないので、管理者だけがログインして使う別の小さなノートを作る、というイメージです。
+
+### 日常の例え話
+
+学校の出席簿を考えてみてください。
+
+- **生徒名簿**は別ファイル（これは Google フォーム = 会員データに相当）。
+- **出席簿**は先生だけが書き込めるノート（これが今回作る `meetings` と `meeting_attendances`）。
+- 「4 月 10 日（月）の朝の会、出席者は A さん B さん C さん」と書く欄が `meetings` 表 + `meeting_attendances` 表。
+- 学期末に「4 月の出席状況を Excel で印刷したい」と言われて、CSV ボタンを押すと一覧が出てくる、これが `export.csv`。
+
+そして「先生以外の生徒が出席簿を書き換えられたら困る」ので、職員室の鍵（= admin session cookie）を持っている人しか開けないようにします。これが `requireAdmin` middleware です。鍵が 2 つ必要（apps/web の middleware と apps/api の requireAdmin）なのは、職員室のドアと出席簿が入った金庫の両方に鍵をかけるのと同じ理由です。片方の鍵が壊れても、もう片方が守ってくれる仕組みです。
+
+## 実行タスク
+
+1. `outputs/phase-12/implementation-guide.md` を作る。完了条件: 実装担当者が runbook に沿って手戻りなく進められる。
+2. `outputs/phase-12/system-spec-update-summary.md` を作る。完了条件: `11-admin-management.md` 等への追記差分が表現される。
+3. `outputs/phase-12/documentation-changelog.md` を作る。完了条件: 変更ファイル一覧と理由が出る。
+4. `outputs/phase-12/unassigned-task-detection.md` を作る。完了条件: 未割当の followup（例: meetings 自動繰り返し、本人セルフ申告 UI）が一覧化される。
+5. `outputs/phase-12/skill-feedback-report.md` を作る。完了条件: task-specification-creator skill 利用上の改善点が記録される。
+6. `outputs/phase-12/phase12-task-spec-compliance-check.md` を作る。完了条件: 13 phase の必須セクション充足が ✅ で記録される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/11-admin-management.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/13-mvp-auth.md
+- outputs/phase-01/main.md 〜 outputs/phase-11/main.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成ではアプリケーションコード、D1 migration 適用、deploy、commit、push、PR 作成を行わない。
+- 中学生レベル説明は「専門用語の前に必ず日常の例え話を添える」原則で書く。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- 専門用語に必ず例え話 / 平易な言い換えが付いているか。
+
+## サブタスク管理
+
+- [ ] implementation-guide.md を作る
+- [ ] system-spec-update-summary.md を作る
+- [ ] documentation-changelog.md を作る
+- [ ] unassigned-task-detection.md を作る
+- [ ] skill-feedback-report.md を作る
+- [ ] phase12-task-spec-compliance-check.md を作る
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+- outputs/phase-12/implementation-guide.md
+- outputs/phase-12/system-spec-update-summary.md
+- outputs/phase-12/documentation-changelog.md
+- outputs/phase-12/unassigned-task-detection.md
+- outputs/phase-12/skill-feedback-report.md
+- outputs/phase-12/phase12-task-spec-compliance-check.md
+
+## 完了条件
+
+- 6 種類のドキュメントが揃う
+- 中学生レベル説明と日常の例え話が含まれる
+- 未割当 followup が漏れなく抽出される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、ドキュメント一式と未割当 followup を渡す。

--- a/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/06c-E-admin-meetings/phase-13.md
@@ -1,0 +1,80 @@
+# Phase 13: PR 作成 — 06c-E-admin-meetings
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 06c-E-admin-meetings |
+| phase | 13 / 13 |
+| wave | 06c-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+user approval を得て PR を作る手順、local check 結果、change summary、PR template を確定する。
+
+## 実行タスク
+
+1. user approval gate を確認する。完了条件: 承認なしには push / PR を行わない宣言が記録される。
+2. local-check-result（typecheck / lint / test の実行ログ要約）を貼る。完了条件: 失敗時の rollback ステップがある。
+3. change-summary（変更ファイル一覧 / 追加 endpoint / 追加 D1 table / 追加 UI route）を書く。完了条件: artifacts.json と一致する。
+4. PR template を書く（タイトル / Summary / Test plan / 関連 Issue / Co-Authored-By）。完了条件: `gh pr create --base dev` を踏む順序が決まる。
+
+## 参照資料
+
+- CLAUDE.md（ブランチ戦略 / Git Safety Protocol）
+- outputs/phase-12/documentation-changelog.md
+- outputs/phase-12/implementation-guide.md
+- outputs/phase-11/main.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/06c-E-admin-meetings/
+- 本仕様書作成では PR を作らない。実装後の PR 作成は user approval 後に `gh pr create` を踏む。
+- `--no-verify` を使わない。hook 失敗時は新規 commit で修正する。
+
+## 統合テスト連携
+
+- 上流: 06c admin pages 本体, 06b-followup-002 session resolver
+- 下流: 08b admin meetings E2E, 09a staging admin smoke
+
+## 多角的チェック観点
+
+- #4 admin-managed data 分離
+- #5 apps/web D1 direct access forbidden
+- #13 audit log
+- #15 Auth session boundary
+- secret / cookie 値が PR 本文・diff・スクリーンショットに混入しないか。
+
+## サブタスク管理
+
+- [ ] user approval gate を明記する
+- [ ] local-check-result を書く
+- [ ] change-summary を書く
+- [ ] PR template を書く
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+- outputs/phase-13/pr-template.md（PR 本文の雛形）
+
+## 完了条件
+
+- user approval gate が明文化される
+- local check が green であることが前提条件として書かれる
+- PR template が `gh pr create --body` にそのまま流せる粒度になる
+- secret 混入リスクの最終チェック項目がある
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] follow-up gate の仕様になっている
+- [ ] 仕様書作成段階で PR を作成していない
+
+## 次 Phase への引き渡し
+
+なし（最終 phase）。user approval が降りた段階で実装担当が PR を作成する。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/artifacts.json
@@ -1,0 +1,216 @@
+{
+  "task_name": "08a-A-public-use-case-coverage-hardening",
+  "task_path": "docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening",
+  "wave": "8a-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "08a partial close-out",
+    "04a public API implementation"
+  ],
+  "blocks": [
+    "08a-B-public-search-filter-coverage",
+    "09a-A-staging-deploy-smoke-execution",
+    "09b-A-observability-sentry-slack-runtime-smoke",
+    "09c-A-production-deploy-execution"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "NON_VISUAL",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md",
+    "docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/",
+    "docs/00-getting-started-manual/specs/01-api-schema.md",
+    "docs/00-getting-started-manual/specs/03-data-fetching.md"
+  ],
+  "endpoints": [],
+  "d1_tables": [],
+  "ui_routes": [],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#1 responseEmail system field",
+    "#2 responseId/memberId separation",
+    "#5 public/member/admin boundary",
+    "#6 apps/web D1 direct access forbidden"
+  ],
+  "doc_references": [
+    "docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md",
+    "docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/",
+    "docs/00-getting-started-manual/specs/01-api-schema.md",
+    "docs/00-getting-started-manual/specs/03-data-fetching.md"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/index.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/index.md
@@ -1,0 +1,106 @@
+# 08a-A-public-use-case-coverage-hardening
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 8a-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+08a の AC-6 PARTIAL を解消するため public use-case / route coverage を補強する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、正本上で未実装・未実測として残った follow-up gate だけを扱う。
+
+08a は 442 tests PASS だが coverage が Statements/Functions/Lines 85% を下回り、AC-6 が PARTIAL のまま残っている。主因は public use-case と route handler の直接テスト不足である。
+
+## scope in / out
+
+### Scope In
+- public form-preview use-case test
+- public member profile use-case test
+- public members use-case test
+- public stats use-case test
+- 必要最小限の public route handler test
+- coverage evidence 更新
+
+### Scope Out
+- UI visual regression
+- production load test
+- shared package type-test 導入
+- coverage exclude による数値合わせ
+
+## dependencies
+
+### Depends On
+- 08a partial close-out
+- 04a public API implementation
+
+### Blocks
+- 08a-B-public-search-filter-coverage
+- 09a-A-staging-deploy-smoke-execution（staging smoke）
+- 09b-A-observability-sentry-slack-runtime-smoke（release runbook）
+- 09c-A-production-deploy-execution（production deploy gate）
+
+## refs
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## AC
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-01/main.md
@@ -1,0 +1,5 @@
+# outputs phase 01: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 要件定義
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-02/main.md
@@ -1,0 +1,5 @@
+# outputs phase 02: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 設計
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-03/main.md
@@ -1,0 +1,5 @@
+# outputs phase 03: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 設計レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-04/main.md
@@ -1,0 +1,5 @@
+# outputs phase 04: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: テスト戦略
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-05/main.md
@@ -1,0 +1,5 @@
+# outputs phase 05: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 実装ランブック
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-06/main.md
@@ -1,0 +1,5 @@
+# outputs phase 06: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 異常系検証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-07/main.md
@@ -1,0 +1,5 @@
+# outputs phase 07: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: AC マトリクス
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-08/main.md
@@ -1,0 +1,5 @@
+# outputs phase 08: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: DRY 化
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-09/main.md
@@ -1,0 +1,5 @@
+# outputs phase 09: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 品質保証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-10/main.md
@@ -1,0 +1,5 @@
+# outputs phase 10: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 最終レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-11/main.md
@@ -1,0 +1,5 @@
+# outputs phase 11: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: 手動 smoke / 実測 evidence
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-12/main.md
@@ -1,0 +1,5 @@
+# outputs phase 12: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: ドキュメント更新
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/outputs/phase-13/main.md
@@ -1,0 +1,5 @@
+# outputs phase 13: 08a-A-public-use-case-coverage-hardening
+
+- status: pending
+- purpose: PR 作成
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 1 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 2 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実行構造、evidence path、依存 matrix、rollback/skip 条件を設計する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 3 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+代替案、リスク、GO/NO-GO 条件をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 4 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+unit/contract/E2E/manual smoke/authorization の検証戦略を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 5 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+コード実装または実行操作の runbook を定義する。実行自体はこの仕様書作成では行わない。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 6 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+401/403/404/409/422/5xx、secret 不備、runtime drift、flaky を検証する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 7 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+AC と検証・evidence の対応表を作る。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 8 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+既存タスクとの重複、命名、evidence path、状態語彙を整理する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 9 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+free-tier、secret hygiene、a11y、運用リスクを確認する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 10 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+上流 gate と blocker を踏まえて GO/NO-GO を判定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 11 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実測 evidence の取得手順と保存先を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-12.md
@@ -1,0 +1,78 @@
+# Phase 12: ドキュメント更新 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 12 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 08a-A-public-use-case-coverage-hardening
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-A-public-use-case-coverage-hardening |
+| phase | 13 / 13 |
+| wave | 8a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+commit / PR / deploy / production mutation の user approval gate を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-08A-01-public-use-case-coverage-hardening.md
+- docs/30-workflows/08a-parallel-api-contract-repository-and-authorization-tests/
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/03-data-fetching.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-A-public-use-case-coverage-hardening/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a partial close-out, 04a public API implementation
+- 下流: 09a staging smoke, 09b release runbook, 09c production deploy gate
+
+## 多角的チェック観点
+
+- #1 responseEmail system field
+- #2 responseId/memberId separation
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- public use-case 4本に happy/null-or-empty/D1-fail の最低3ケースずつ追加される
+- API test が green
+- coverage Statements >=85%, Branches >=80%, Functions >=85%, Lines >=85%
+- 08a artifacts の partial 判定更新方針が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/artifacts.json
@@ -1,0 +1,224 @@
+{
+  "task_name": "08a-B-public-search-filter-coverage",
+  "task_path": "docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage",
+  "wave": "08a-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "08a-A-public-use-case-coverage-hardening",
+    "07a tag resolve API",
+    "06a public web real workers d1 smoke"
+  ],
+  "blocks": [
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/00-getting-started-manual/specs/12-search-tags.md",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/01-api-schema.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx"
+  ],
+  "endpoints": [
+    "GET /api/public/members?q&zone&status&tag&sort"
+  ],
+  "d1_tables": [
+    "members",
+    "tags",
+    "member_tags"
+  ],
+  "ui_routes": [
+    "/members"
+  ],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#4 公開状態フィルタ正確性",
+    "#5 public/member/admin boundary",
+    "#6 admin-only field を public response に含めない"
+  ],
+  "doc_references": [
+    "docs/00-getting-started-manual/specs/12-search-tags.md",
+    "docs/00-getting-started-manual/specs/05-pages.md",
+    "docs/00-getting-started-manual/specs/01-api-schema.md",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    "docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/index.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/index.md
@@ -1,0 +1,112 @@
+# 08a-B-public-search-filter-coverage
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 08a-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL |
+
+## purpose
+
+公開メンバー一覧 `/members` の検索/フィルタ機能（q / zone / status / tag / sort / density）の動作仕様を `12-search-tags.md` 正本に沿って固定し、08a coverage hardening でカバーされていない検索パラメータの spec gap を解消する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、08a-A の use-case coverage では扱わない検索パラメータ仕様（query string ↔ API ↔ UI 表示の三者整合）だけを follow-up として固定する。
+
+`/members` のフィルタ UI は `claude-design-prototype/pages-public.jsx` に存在するが、本番経路で query parameter 受け取り → API 渡し → 結果反映 → URL 同期 の一連の動作仕様が確定していないため、08b E2E と 09a staging smoke の検索シナリオが書けない状態にある。
+
+## scope in / out
+
+### Scope In
+- `/members?q=&zone=&status=&tag=&sort=&density=` のパラメータ仕様
+- public API `GET /api/public/members` の同パラメータ受け取り挙動
+- 部分一致 / enum / multi-tag / sort / density 各々の AC
+- 空結果 / 不正値 / 大量ヒットの UI 挙動仕様
+- a11y（filter UI のキーボード操作・aria）
+- visual evidence path（Playwright screenshot）
+
+### Scope Out
+- tag 管理 UI（admin 側）の実装
+- search index 化 / 全文検索エンジン導入
+- pagination 仕様の再定義（既存 03-data-fetching.md に従う）
+- 非公開フィールドの公開 API 露出変更
+
+## dependencies
+
+### Depends On
+- 08a-A-public-use-case-coverage-hardening（base coverage）
+- 07a tag resolve API 本体
+- 06a public web real workers / d1 smoke
+
+### Blocks
+- 08b-A-playwright-e2e-full-execution（検索 E2E シナリオ）
+- 09a-A-staging-deploy-smoke-execution（検索 smoke）
+
+## refs
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## AC
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値（enum 外, 過大文字数）/ 大量ヒット（>=200件）の UI 挙動が記述される
+- a11y: filter input が role / label / keyboard 操作で全て到達可能と明記される
+- 不変条件 #4 公開状態フィルタ正確性 / #5 public boundary / #6 admin-only field 非露出 が AC として明文化される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## services / secrets
+
+- Cloudflare Workers (apps/web, apps/api)
+- Cloudflare D1（read-only, public scope）
+- secret 追加なし
+
+## invariants touched
+
+- #4 公開状態フィルタ正確性（status=非公開/退会済みは public 結果から除外）
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+
+## completion definition
+
+全 phase 仕様書が揃い、検索パラメータごとの AC と evidence path、a11y 観点が明記され、08b E2E / 09a smoke が参照できる状態になること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 1 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。検索/フィルタ仕様の gap を一覧化し、AC を query parameter 単位で固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 2 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+query parameter ↔ API ↔ UI 表示の三者整合と evidence path、依存 matrix、module 設計を Mermaid と表で固める。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、設計図、依存 matrix、module 設計を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 3 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+simpler alternative 3案以上（クライアント側 filter のみ案 / API 側 filter 案 / hybrid 案）を比較し PASS-MINOR-MAJOR を判定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、選定された案と PASS 判定理由を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 4 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+unit / contract / E2E / a11y のテスト戦略を 6種パラメータ × 既知ケース（happy / 空結果 / 不正値）で先に設計する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、verify suite と test 構造を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 5 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実装手順を runbook 化し、query parser / API handler / UI 同期 を placeholder と擬似コードで書く。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、実装 runbook と placeholder を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 6 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+空結果 / enum 外 zone-status 値 / 過大文字数 q（>200 chars）/ >=200 件大量ヒット / 不正 sort / 未知 tag id の異常系を洗う。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、異常系シナリオと期待挙動を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 7 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+AC マトリクスで Phase 1 AC × Phase 4 検証 × Phase 5 実装 を一対一対応させる。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC マトリクスと検証対応表を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 8 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+query key / type / path / endpoint / module 名（searchParams schema・SearchQuery 型）を DRY 化し、shared schema を確定する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、DRY 化された型 / schema / endpoint を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 9 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+型安全 / lint / test / a11y（filter UI のキーボード・aria）/ 無料枠 / secret hygiene を確認する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、品質チェック結果と無料枠見積もりを渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 10 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+GO/NO-GO 判定と blocker 一覧、上流 wave AC 充足を確認する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、GO/NO-GO 判定と blocker 一覧を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 11 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+手動 smoke の手順、Playwright screenshot 保存先（outputs/phase-11/screenshots/）、curl での API 確認コマンドを書く。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、manual evidence path と smoke 手順を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-12.md
@@ -1,0 +1,110 @@
+# Phase 12: ドキュメント更新 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 12 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。implementation-guide / system-spec-update-summary / documentation-changelog / unassigned-task-detection / skill-feedback-report / phase12-task-spec-compliance-check を生成する。
+
+## 中学生レベル概念説明
+
+「検索とフィルタ」を中学生にもわかる言葉で説明すると次のとおり。
+
+- **q（キーワード検索）**: 入力した文字を含む人を見つける。例: 「鈴木」と入れたら名前の一部に「鈴木」がある人だけが残る。
+- **zone（地域）**: 神戸・阪神・播磨など、決まったリスト（enum）から1つ選ぶ。書いていない地域名は受け付けない。
+- **status（公開状態）**: 「公開」「非公開」「退会済み」のうち、公開のページでは「公開」だけが見える。これは不変条件 #4 で守る決まり。
+- **tag（タグ）**: 「ピアノ」「合唱」のような印を複数つけられる。複数選ぶと「全部当てはまる人」だけが残る（AND 条件）。
+- **sort（並び順）**: 名前順 / 入会日順 / 更新日順から選ぶ。
+- **density（表示密度）**: カードを詰めて並べるか、ゆったり並べるかの見た目だけの設定。
+
+## 日常の例え話
+
+図書館で本を探す場面に例える。
+
+- **q** はタイトル検索の入力欄。「ハリー」と入れると「ハリー・ポッター」が出る。
+- **zone** は「文学コーナー / 児童書コーナー / 専門書コーナー」のフロア選択。
+- **status** は「貸出可 / 貸出中 / 廃棄済み」。利用者には貸出可だけ見せる（廃棄済みを見せたら混乱する＝ #4 公開状態フィルタ正確性）。
+- **tag** は本に貼られた「冒険」「ミステリー」シール。2枚選んだら両方貼られた本だけが残る。
+- **sort** は「あいうえお順 / 新着順 / 人気順」の並べ替え。
+- **density** は「本棚に詰めて並べるか / 表紙を大きく見せるか」の陳列方法。
+
+司書（API）が本（メンバー）を絞り込み、利用者（公開ページ訪問者）が見られるのは貸出可のものだけ、という構造が #5 public boundary と同じ役割をしている。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 接続漏れの境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] implementation-guide.md の更新方針を記述
+- [ ] system-spec-update-summary.md（12-search-tags.md 連携）
+- [ ] documentation-changelog.md
+- [ ] unassigned-task-detection.md
+- [ ] skill-feedback-report.md
+- [ ] phase12-task-spec-compliance-check.md
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+- outputs/phase-12/implementation-guide.md
+- outputs/phase-12/system-spec-update-summary.md
+- outputs/phase-12/documentation-changelog.md
+- outputs/phase-12/unassigned-task-detection.md
+- outputs/phase-12/skill-feedback-report.md
+- outputs/phase-12/phase12-task-spec-compliance-check.md
+
+## 完了条件
+
+- 検索パラメータ 6種の AC と evidence path が正本仕様に逆反映される更新方針が記述される
+- 12-search-tags.md / 05-pages.md / 01-api-schema.md への追記内容が specified
+- 残作業（08b E2E / 09a smoke）への引き継ぎ事項が明示される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 中学生レベル概念説明と日常の例え話が含まれる
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、ドキュメント更新方針と changelog を渡す。

--- a/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 08a-B-public-search-filter-coverage
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08a-B-public-search-filter-coverage |
+| phase | 13 / 13 |
+| wave | 08a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+user approval gate、local-check-result、change-summary、PR template を確定する。feature/* → dev → main の経路を踏襲する。
+
+## 実行タスク
+
+1. 参照資料と該当ソースを確認する。完了条件: 未確定の検索仕様の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path（screenshot / curl）が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作（実装・deploy・PR）が明記される。
+
+## 参照資料
+
+- docs/00-getting-started-manual/specs/12-search-tags.md
+- docs/00-getting-started-manual/specs/05-pages.md
+- docs/00-getting-started-manual/specs/01-api-schema.md
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- docs/00-getting-started-manual/claude-design-prototype/pages-public.jsx
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08a-B-public-search-filter-coverage/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a-followup-001 base coverage, 07a tag resolve API, 06a public web smoke
+- 下流: 08b playwright e2e（検索シナリオ）, 09a staging smoke（検索 smoke）
+
+## 多角的チェック観点
+
+- #4 公開状態フィルタ正確性
+- #5 public/member/admin boundary
+- #6 admin-only field を public response に含めない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- query parameter 6種（q / zone / status / tag / sort / density）すべてに対し既知ケースが spec として記述される
+- `GET /api/public/members` の query 受け取り型と response 形が確定する
+- 空結果 / 不正値 / 大量ヒットの UI 挙動が記述される
+- a11y 観点が AC として明文化される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+完了。user approval 待ち。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/artifacts.json
@@ -1,0 +1,214 @@
+{
+  "task_name": "08b-A-playwright-e2e-full-execution",
+  "task_path": "docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution",
+  "wave": "8b-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "06a public pages",
+    "06b member pages",
+    "06c admin pages",
+    "07a/07b/07c admin ops"
+  ],
+  "blocks": [
+    "09a staging deploy smoke"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md",
+    "docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    ".claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md"
+  ],
+  "endpoints": [],
+  "d1_tables": [],
+  "ui_routes": [],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#5 public/member/admin boundary",
+    "#8 localStorage/GAS prototype を正本にしない",
+    "#9 /no-access 専用画面に依存しない"
+  ],
+  "doc_references": [
+    "docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md",
+    "docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/",
+    "docs/00-getting-started-manual/specs/09-ui-ux.md",
+    ".claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/index.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/index.md
@@ -1,0 +1,112 @@
+# 08b-A-playwright-e2e-full-execution
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 8b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL |
+
+## purpose
+
+08b scaffolding-only の Playwright を full execution に昇格し、実 screenshot / axe / report を取得する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、正本上で未実装・未実測として残った follow-up gate だけを扱う。
+
+08b は page objects と skipped specs の scaffold までで閉じており、実 screenshot、real axe report、Playwright report、CI gate が未完了である。
+
+## scope in / out
+
+### Scope In
+- `test.describe.skip` の解除計画
+- Auth.js 互換 fixture または UI login helper 方針
+- D1 seed/reset 方針
+- desktop/mobile screenshot evidence
+- Playwright HTML/JSON report と axe report
+- PR/push CI gate 昇格条件
+- **admin 二段防御 E2E シナリオ**（`06-member-auth.md`, `11-admin-management.md` 由来）
+  - 非 admin session で `/admin/*` 直接アクセス → UI gate (middleware) で 403 もしくは redirect
+  - 非 admin session で `/api/admin/*` 直接呼び出し → API gate (require-admin) で 403
+  - admin session でも他人本文の編集 endpoint は 403（invariants #11）
+  - UI gate を bypass しても API gate 単独で防御が成立することの evidence（UI を介さない direct fetch test）
+
+### Scope Out
+- production 負荷テスト
+- visual regression baseline の全面導入
+- 09a staging deploy 本体
+- 新規 UI 機能追加
+
+## dependencies
+
+### Depends On
+- 06a public pages
+- 06b member pages
+- 06c admin pages
+- 07a/07b/07c admin ops
+
+### Blocks
+- 09a staging deploy smoke
+
+## refs
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## AC
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+- admin UI gate / API gate の独立性 E2E が PASS（UI を bypass した direct API call も 403 であること）
+- 非 admin による `/admin/*` および `/api/admin/*` 双方の 403/redirect evidence が保存される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-01/main.md
@@ -1,0 +1,5 @@
+# outputs phase 01: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 要件定義
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-02/main.md
@@ -1,0 +1,5 @@
+# outputs phase 02: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 設計
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-03/main.md
@@ -1,0 +1,5 @@
+# outputs phase 03: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 設計レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-04/main.md
@@ -1,0 +1,5 @@
+# outputs phase 04: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: テスト戦略
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-05/main.md
@@ -1,0 +1,5 @@
+# outputs phase 05: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 実装ランブック
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-06/main.md
@@ -1,0 +1,5 @@
+# outputs phase 06: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 異常系検証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-07/main.md
@@ -1,0 +1,5 @@
+# outputs phase 07: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: AC マトリクス
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-08/main.md
@@ -1,0 +1,5 @@
+# outputs phase 08: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: DRY 化
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-09/main.md
@@ -1,0 +1,5 @@
+# outputs phase 09: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 品質保証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-10/main.md
@@ -1,0 +1,5 @@
+# outputs phase 10: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 最終レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-11/main.md
@@ -1,0 +1,5 @@
+# outputs phase 11: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: 手動 smoke / 実測 evidence
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-12/main.md
@@ -1,0 +1,5 @@
+# outputs phase 12: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: ドキュメント更新
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/outputs/phase-13/main.md
@@ -1,0 +1,5 @@
+# outputs phase 13: 08b-A-playwright-e2e-full-execution
+
+- status: pending
+- purpose: PR 作成
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 1 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 2 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実行構造、evidence path、依存 matrix、rollback/skip 条件を設計する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 3 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+代替案、リスク、GO/NO-GO 条件をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 4 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+unit/contract/E2E/manual smoke/authorization の検証戦略を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 5 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+コード実装または実行操作の runbook を定義する。実行自体はこの仕様書作成では行わない。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 6 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+401/403/404/409/422/5xx、secret 不備、runtime drift、flaky を検証する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 7 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+AC と検証・evidence の対応表を作る。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 8 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+既存タスクとの重複、命名、evidence path、状態語彙を整理する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 9 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+free-tier、secret hygiene、a11y、運用リスクを確認する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 10 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+上流 gate と blocker を踏まえて GO/NO-GO を判定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 11 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実測 evidence の取得手順と保存先を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-12.md
@@ -1,0 +1,78 @@
+# Phase 12: ドキュメント更新 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 12 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 08b-A-playwright-e2e-full-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 08b-A-playwright-e2e-full-execution |
+| phase | 13 / 13 |
+| wave | 8b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+commit / PR / deploy / production mutation の user approval gate を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-08b-playwright-e2e-full-execution-001.md
+- docs/30-workflows/08b-parallel-playwright-e2e-and-ui-acceptance-smoke/
+- docs/00-getting-started-manual/specs/09-ui-ux.md
+- .claude/skills/aiworkflow-requirements/references/testing-playwright-e2e.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/08b-A-playwright-e2e-full-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 06a public pages, 06b member pages, 06c admin pages, 07a/07b/07c admin ops
+- 下流: 09a staging deploy smoke
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #8 localStorage/GAS prototype を正本にしない
+- #9 /no-access 専用画面に依存しない
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- skipped spec が 0 件になる条件が定義される
+- 実 Playwright report が保存される
+- real axe report が保存される
+- desktop/mobile screenshot が保存される
+- CI gate 昇格前の secret hygiene が明記される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/artifacts.json
@@ -1,0 +1,212 @@
+{
+  "task_name": "09a-A-staging-deploy-smoke-execution",
+  "task_path": "docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution",
+  "wave": "9a-fu",
+  "execution_mode": "parallel",
+  "depends_on": [
+    "08a coverage gate",
+    "08b E2E evidence",
+    "Cloudflare staging secrets",
+    "staging Pages/Workers target"
+  ],
+  "blocks": [
+    "09c production deploy execution"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL_ON_EXECUTION",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md",
+    "docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/",
+    "docs/00-getting-started-manual/specs/15-infrastructure-runbook.md"
+  ],
+  "endpoints": [],
+  "d1_tables": [],
+  "ui_routes": [],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#5 public/member/admin boundary",
+    "#6 apps/web D1 direct access forbidden",
+    "#14 Cloudflare free-tier"
+  ],
+  "doc_references": [
+    "docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md",
+    "docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/",
+    "docs/00-getting-started-manual/specs/15-infrastructure-runbook.md"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/index.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/index.md
@@ -1,0 +1,112 @@
+# 09a-A-staging-deploy-smoke-execution
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 9a-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## purpose
+
+09a の NOT_EXECUTED placeholder を実 staging evidence に置換する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、正本上で未実装・未実測として残った follow-up gate だけを扱う。
+
+09a は staging deploy smoke / Forms sync validation の実行仕様を完了しているが、実 staging 環境の deploy smoke、UI visual smoke、Forms sync validation は未実行である。09c production deploy の前提にできない。
+
+## scope in / out
+
+### Scope In
+- staging web/api deploy smoke
+- 公開/ログイン/profile/admin の visual smoke
+- Forms schema/responses sync validation
+- sync_jobs/audit evidence
+- wrangler tail redacted log
+- 09c blocker 更新
+- **D1 schema / migration 整合性検証**（`08-free-database.md` 由来）
+  - `wrangler d1 migrations list ubm-hyogo-db-staging --env staging` の出力 evidence
+  - production と staging の schema parity 確認（table 一覧 / `PRAGMA table_info` 等の比較）
+  - migration applied 行と pending 行の数値 evidence
+  - `members`/`sync_jobs`/`audit_log` 主要テーブルの indexes / constraints が正本仕様 (`08-free-database.md`) と一致すること
+
+### Scope Out
+- production deploy
+- 新規 UI/API 機能追加
+- secret 値の文書化
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 08a coverage gate
+- 08b E2E evidence
+- Cloudflare staging secrets
+- staging Pages/Workers target
+
+### Blocks
+- 09c production deploy execution
+
+## refs
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- docs/00-getting-started-manual/specs/08-free-database.md（D1 schema / migration 正本）
+
+## AC
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+- D1 staging migration list が Applied のみで pending=0 であること、または pending がある場合は理由 evidence が残ること
+- D1 schema parity (staging vs production) の差分が 0、または差分がある場合は production 側 migration TODO が unassigned-task に発行されること
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-01/main.md
@@ -1,0 +1,5 @@
+# outputs phase 01: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 要件定義
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-02/main.md
@@ -1,0 +1,5 @@
+# outputs phase 02: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 設計
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-03/main.md
@@ -1,0 +1,5 @@
+# outputs phase 03: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 設計レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-04/main.md
@@ -1,0 +1,5 @@
+# outputs phase 04: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: テスト戦略
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-05/main.md
@@ -1,0 +1,5 @@
+# outputs phase 05: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 実装ランブック
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-06/main.md
@@ -1,0 +1,5 @@
+# outputs phase 06: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 異常系検証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-07/main.md
@@ -1,0 +1,5 @@
+# outputs phase 07: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: AC マトリクス
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-08/main.md
@@ -1,0 +1,5 @@
+# outputs phase 08: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: DRY 化
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-09/main.md
@@ -1,0 +1,5 @@
+# outputs phase 09: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 品質保証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-10/main.md
@@ -1,0 +1,5 @@
+# outputs phase 10: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 最終レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-11/main.md
@@ -1,0 +1,5 @@
+# outputs phase 11: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: 手動 smoke / 実測 evidence
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-12/main.md
@@ -1,0 +1,5 @@
+# outputs phase 12: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: ドキュメント更新
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/outputs/phase-13/main.md
@@ -1,0 +1,5 @@
+# outputs phase 13: 09a-A-staging-deploy-smoke-execution
+
+- status: pending
+- purpose: PR 作成
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-01.md
@@ -1,0 +1,77 @@
+# Phase 1: 要件定義 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 1 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-02.md
@@ -1,0 +1,77 @@
+# Phase 2: 設計 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 2 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実行構造、evidence path、依存 matrix、rollback/skip 条件を設計する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-03.md
@@ -1,0 +1,77 @@
+# Phase 3: 設計レビュー — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 3 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+代替案、リスク、GO/NO-GO 条件をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-04.md
@@ -1,0 +1,77 @@
+# Phase 4: テスト戦略 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 4 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+unit/contract/E2E/manual smoke/authorization の検証戦略を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-05.md
@@ -1,0 +1,77 @@
+# Phase 5: 実装ランブック — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 5 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+コード実装または実行操作の runbook を定義する。実行自体はこの仕様書作成では行わない。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-06.md
@@ -1,0 +1,77 @@
+# Phase 6: 異常系検証 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 6 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+401/403/404/409/422/5xx、secret 不備、runtime drift、flaky を検証する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-07.md
@@ -1,0 +1,77 @@
+# Phase 7: AC マトリクス — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 7 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+AC と検証・evidence の対応表を作る。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-08.md
@@ -1,0 +1,77 @@
+# Phase 8: DRY 化 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 8 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+既存タスクとの重複、命名、evidence path、状態語彙を整理する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-09.md
@@ -1,0 +1,77 @@
+# Phase 9: 品質保証 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 9 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+free-tier、secret hygiene、a11y、運用リスクを確認する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-10.md
@@ -1,0 +1,77 @@
+# Phase 10: 最終レビュー — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 10 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+上流 gate と blocker を踏まえて GO/NO-GO を判定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-11.md
@@ -1,0 +1,77 @@
+# Phase 11: 手動 smoke / 実測 evidence — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 11 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+実測 evidence の取得手順と保存先を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-12.md
@@ -1,0 +1,77 @@
+# Phase 12: ドキュメント更新 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 12 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/phase-13.md
@@ -1,0 +1,77 @@
+# Phase 13: PR 作成 — 09a-A-staging-deploy-smoke-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09a-A-staging-deploy-smoke-execution |
+| phase | 13 / 13 |
+| wave | 9a-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL_ON_EXECUTION |
+
+## 目的
+
+commit / PR / deploy / production mutation の user approval gate を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09a-exec-staging-smoke-001.md
+- docs/30-workflows/09a-parallel-staging-deploy-smoke-and-forms-sync-validation/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09a-A-staging-deploy-smoke-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 08a coverage gate, 08b E2E evidence, Cloudflare staging secrets, staging Pages/Workers target
+- 下流: 09c production deploy execution
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- 09a Phase 11 の NOT_EXECUTED が実 evidence に置換される
+- UI/authz/admin route smoke evidence が保存される
+- Forms schema/responses sync evidence が保存される
+- wrangler tail または取得不能理由が保存される
+- 09c blocker が実測結果で更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/artifacts.json
@@ -1,0 +1,87 @@
+{
+  "task": "09b-A-observability-sentry-slack-runtime-smoke",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "docsOnly": true,
+  "remainingOnly": true,
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/index.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/index.md
@@ -1,0 +1,105 @@
+# 09b-A-observability-sentry-slack-runtime-smoke
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 09b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+Sentry DSN 登録と Slack alert 疎通を実運用証跡として確定する。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、現状コード・正本仕様・未割当タスクを照合して残った未実装または未運用 gate だけを扱う。
+
+09b の incident response / observability 設計は存在するが、Sentry project 受信確認と Slack webhook/workflow の実疎通は未実施タスクとして残っている。production release 前に障害検知が人手確認だけに依存しない状態へ進める。
+
+## scope in / out
+
+### Scope In
+- Sentry DSN の secret 配置 runbook
+- staging test event 受信 smoke
+- Slack webhook/workflow secret 配置 runbook
+- Slack test alert smoke
+- secret 値を残さない evidence 保存
+
+### Scope Out
+- 有償 plan 契約の強制
+- 汎用通知基盤 UT-07 全実装
+- PagerDuty 連携
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 09b incident response runbook
+- deployment-secrets-management
+- observability-monitoring
+- 1Password 正本 secret 管理
+
+### Blocks
+- 09c production deploy readiness
+- incident response automation confidence
+
+## refs
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## AC
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-01/main.md
@@ -1,0 +1,17 @@
+# Output Phase 1: 要件定義
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-02/main.md
@@ -1,0 +1,17 @@
+# Output Phase 2: 設計
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-03/main.md
@@ -1,0 +1,17 @@
+# Output Phase 3: 設計レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-04/main.md
@@ -1,0 +1,17 @@
+# Output Phase 4: テスト戦略
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-05/main.md
@@ -1,0 +1,17 @@
+# Output Phase 5: 実装ランブック
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-06/main.md
@@ -1,0 +1,17 @@
+# Output Phase 6: 異常系検証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-07/main.md
@@ -1,0 +1,17 @@
+# Output Phase 7: AC マトリクス
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-08/main.md
@@ -1,0 +1,17 @@
+# Output Phase 8: DRY 化
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-09/main.md
@@ -1,0 +1,17 @@
+# Output Phase 9: 品質保証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-10/main.md
@@ -1,0 +1,17 @@
+# Output Phase 10: 最終レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-11/main.md
@@ -1,0 +1,17 @@
+# Output Phase 11: 手動 smoke / 実測 evidence
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-12/main.md
@@ -1,0 +1,17 @@
+# Output Phase 12: ドキュメント更新
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/outputs/phase-13/main.md
@@ -1,0 +1,17 @@
+# Output Phase 13: PR 作成
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 1 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 2 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+最小責務で実装・運用設計を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 3 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 4 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+自動・手動・外部環境検証の境界を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 5 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実装または運用実行時の手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 6 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+失敗時、未設定時、権限不足時の挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 7 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+受入条件と evidence path を一対一に対応付ける。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 8 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+重複手順、重複設定、重複責務を削減する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 9 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+型、lint、test、security、observability の品質 gate を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 10 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実行前の最終判断材料を揃える。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 11 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+人手または外部環境でしか確認できない証跡を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-12.md
@@ -1,0 +1,78 @@
+# Phase 12: ドキュメント更新 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 12 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 09b-A-observability-sentry-slack-runtime-smoke
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-A-observability-sentry-slack-runtime-smoke |
+| phase | 13 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+ユーザー承認後のPR作成条件だけを定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-obs-sentry-dsn-registration-001.md
+- docs/30-workflows/unassigned-task/task-obs-slack-notify-001.md
+- .claude/skills/aiworkflow-requirements/references/observability-monitoring.md
+- .claude/skills/aiworkflow-requirements/references/deployment-secrets-management.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-A-observability-sentry-slack-runtime-smoke/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09b incident response runbook, deployment-secrets-management, observability-monitoring, 1Password 正本 secret 管理
+- 下流: 09c production deploy readiness, incident response automation confidence
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #17 incident response readiness
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- Sentry staging test event の受信証跡が保存される
+- Slack test alert の送信証跡が保存される
+- secret 実値が repo/evidence に残らない
+- 失敗時 fallback/保留判断が runbook 化される
+- 09c の observability blocker が更新される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/artifacts.json
@@ -1,0 +1,87 @@
+{
+  "task": "09b-B-cd-post-deploy-smoke-healthcheck",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "docsOnly": true,
+  "remainingOnly": true,
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/index.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/index.md
@@ -1,0 +1,109 @@
+# 09b-B-cd-post-deploy-smoke-healthcheck
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 09b-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+CD デプロイ後の smoke / healthcheck 自動化漏れを埋める。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、現状コード・正本仕様・未割当タスクを照合して残った未実装または未運用 gate だけを扱う。
+
+staging/prod deploy は手動 smoke だけでは drift と silent failure を検知しづらい。UT-29 と正本仕様では post-deploy smoke/healthcheck が未実装として残っており、09a/09c の実行証跡を継続的に再検証する仕組みが必要である。
+
+## scope in / out
+
+### Scope In
+- GitHub Actions または Cloudflare deploy 後の healthcheck 設計
+- web/api health endpoint smoke
+- Pages deployment source drift check
+- D1/Workers 接続の軽量 smoke
+- 失敗時の redacted log/evidence 保存
+
+### Scope Out
+- 全 E2E suite の常時実行化
+- production deploy 実行そのもの
+- 監視基盤全体の再設計
+- 未承認 commit/push/PR
+
+## dependencies
+
+### Depends On
+- 09a staging smoke execution
+- 09c production deploy execution runbook
+- Cloudflare Pages/Workers project settings
+- GitHub Actions secrets
+
+### Blocks
+- 09c-A-production-deploy-execution（healthcheck mechanism が green の状態で初めて production deploy へ進む）
+- production release operational confidence
+- future deploy regression detection
+
+### 因果順序の明確化（思考法分析からの整合）
+- mechanism setup（本タスク）→ staging で動作確認 → production deploy（09c-A）→ deploy 後に同 mechanism が再発火、という因果ループ。
+- 本タスクが先行することで 09c production deploy 失敗時の silent failure を automated に検知可能になる。
+
+## refs
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## AC
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-01/main.md
@@ -1,0 +1,17 @@
+# Output Phase 1: 要件定義
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-02/main.md
@@ -1,0 +1,17 @@
+# Output Phase 2: 設計
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-03/main.md
@@ -1,0 +1,17 @@
+# Output Phase 3: 設計レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-04/main.md
@@ -1,0 +1,17 @@
+# Output Phase 4: テスト戦略
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-05/main.md
@@ -1,0 +1,17 @@
+# Output Phase 5: 実装ランブック
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-06/main.md
@@ -1,0 +1,17 @@
+# Output Phase 6: 異常系検証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-07/main.md
@@ -1,0 +1,17 @@
+# Output Phase 7: AC マトリクス
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-08/main.md
@@ -1,0 +1,17 @@
+# Output Phase 8: DRY 化
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-09/main.md
@@ -1,0 +1,17 @@
+# Output Phase 9: 品質保証
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-10/main.md
@@ -1,0 +1,17 @@
+# Output Phase 10: 最終レビュー
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-11/main.md
@@ -1,0 +1,17 @@
+# Output Phase 11: 手動 smoke / 実測 evidence
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-12/main.md
@@ -1,0 +1,17 @@
+# Output Phase 12: ドキュメント更新
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/outputs/phase-13/main.md
@@ -1,0 +1,17 @@
+# Output Phase 13: PR 作成
+
+## status
+
+NOT_EXECUTED_SPEC_ONLY
+
+## expected evidence when executed
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## notes
+
+このファイルはタスク仕様書作成時点の出力枠であり、実装・deploy・外部 smoke の実行結果ではない。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-01.md
@@ -1,0 +1,77 @@
+# Phase 1: 要件定義 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 1 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-02.md
@@ -1,0 +1,77 @@
+# Phase 2: 設計 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 2 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+最小責務で実装・運用設計を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-03.md
@@ -1,0 +1,77 @@
+# Phase 3: 設計レビュー — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 3 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+矛盾、漏れ、整合性、依存関係をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-04.md
@@ -1,0 +1,77 @@
+# Phase 4: テスト戦略 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 4 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+自動・手動・外部環境検証の境界を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-05.md
@@ -1,0 +1,77 @@
+# Phase 5: 実装ランブック — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 5 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実装または運用実行時の手順を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-06.md
@@ -1,0 +1,77 @@
+# Phase 6: 異常系検証 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 6 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+失敗時、未設定時、権限不足時の挙動を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-07.md
@@ -1,0 +1,77 @@
+# Phase 7: AC マトリクス — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 7 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+受入条件と evidence path を一対一に対応付ける。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-08.md
@@ -1,0 +1,77 @@
+# Phase 8: DRY 化 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 8 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+重複手順、重複設定、重複責務を削減する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-09.md
@@ -1,0 +1,77 @@
+# Phase 9: 品質保証 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 9 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+型、lint、test、security、observability の品質 gate を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-10.md
@@ -1,0 +1,77 @@
+# Phase 10: 最終レビュー — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 10 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+実行前の最終判断材料を揃える。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-11.md
@@ -1,0 +1,77 @@
+# Phase 11: 手動 smoke / 実測 evidence — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 11 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+人手または外部環境でしか確認できない証跡を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-12.md
@@ -1,0 +1,77 @@
+# Phase 12: ドキュメント更新 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 12 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、runbook、lessons learned の同期を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/phase-13.md
@@ -1,0 +1,77 @@
+# Phase 13: PR 作成 — 09b-B-cd-post-deploy-smoke-healthcheck
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09b-B-cd-post-deploy-smoke-healthcheck |
+| phase | 13 / 13 |
+| wave | 09b-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+ユーザー承認後のPR作成条件だけを定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/UT-29-cd-post-deploy-smoke-healthcheck.md
+- .claude/skills/aiworkflow-requirements/references/deployment-details.md
+- .claude/skills/aiworkflow-requirements/references/lessons-learned-ut-28-cloudflare-pages-projects-2026-04.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09b-B-cd-post-deploy-smoke-healthcheck/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke execution, 09c production deploy execution runbook, Cloudflare Pages/Workers project settings, GitHub Actions secrets
+- 下流: production release operational confidence, future deploy regression detection
+
+## 多角的チェック観点
+
+- #14 Cloudflare free-tier
+- #16 secret values never documented
+- #18 deployment drift detection
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- deploy 後に web/api healthcheck が自動実行される
+- Pages deployment source drift が検出される
+- 失敗時に workflow が fail close する
+- secret 実値なしの evidence が保存される
+- 09a/09c の手動 smoke と責務重複しない
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/artifacts.json
@@ -1,0 +1,213 @@
+{
+  "task_name": "09c-A-production-deploy-execution",
+  "task_path": "docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution",
+  "wave": "9c-fu",
+  "execution_mode": "serial",
+  "depends_on": [
+    "09a staging smoke green",
+    "09b release/incident runbook",
+    "Phase 13 user approval"
+  ],
+  "blocks": [
+    "post-release observation follow-ups"
+  ],
+  "created_at": "2026-05-01",
+  "metadata": {
+    "taskType": "implementation-spec",
+    "docs_only": true,
+    "workflow_state": "spec_created",
+    "visualEvidence": "VISUAL",
+    "priority": "High",
+    "scope": "remaining_application_implementation_only"
+  },
+  "phases": [
+    {
+      "phase": 1,
+      "name": "要件定義",
+      "file": "phase-01.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-01/main.md"
+      ],
+      "depends_on_phases": [],
+      "user_approval_required": false
+    },
+    {
+      "phase": 2,
+      "name": "設計",
+      "file": "phase-02.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-02/main.md"
+      ],
+      "depends_on_phases": [
+        1
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 3,
+      "name": "設計レビュー",
+      "file": "phase-03.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-03/main.md"
+      ],
+      "depends_on_phases": [
+        2
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 4,
+      "name": "テスト戦略",
+      "file": "phase-04.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-04/main.md"
+      ],
+      "depends_on_phases": [
+        3
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 5,
+      "name": "実装ランブック",
+      "file": "phase-05.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-05/main.md"
+      ],
+      "depends_on_phases": [
+        4
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 6,
+      "name": "異常系検証",
+      "file": "phase-06.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-06/main.md"
+      ],
+      "depends_on_phases": [
+        5
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 7,
+      "name": "AC マトリクス",
+      "file": "phase-07.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-07/main.md"
+      ],
+      "depends_on_phases": [
+        6
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 8,
+      "name": "DRY 化",
+      "file": "phase-08.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-08/main.md"
+      ],
+      "depends_on_phases": [
+        7
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 9,
+      "name": "品質保証",
+      "file": "phase-09.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-09/main.md"
+      ],
+      "depends_on_phases": [
+        8
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 10,
+      "name": "最終レビュー",
+      "file": "phase-10.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-10/main.md"
+      ],
+      "depends_on_phases": [
+        9
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 11,
+      "name": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-11/main.md"
+      ],
+      "depends_on_phases": [
+        10
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 12,
+      "name": "ドキュメント更新",
+      "file": "phase-12.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-12/main.md"
+      ],
+      "depends_on_phases": [
+        11
+      ],
+      "user_approval_required": false
+    },
+    {
+      "phase": 13,
+      "name": "PR 作成",
+      "file": "phase-13.md",
+      "status": "pending",
+      "outputs": [
+        "outputs/phase-13/main.md"
+      ],
+      "depends_on_phases": [
+        12
+      ],
+      "user_approval_required": true
+    }
+  ],
+  "specs_referenced": [
+    "docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md",
+    "docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/",
+    "docs/00-getting-started-manual/specs/15-infrastructure-runbook.md",
+    ".claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md"
+  ],
+  "endpoints": [],
+  "d1_tables": [],
+  "ui_routes": [],
+  "secrets_introduced": [],
+  "invariants_touched": [
+    "#5 public/member/admin boundary",
+    "#6 apps/web D1 direct access forbidden",
+    "#14 Cloudflare free-tier"
+  ],
+  "doc_references": [
+    "docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md",
+    "docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/",
+    "docs/00-getting-started-manual/specs/15-infrastructure-runbook.md",
+    ".claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md"
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/index.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/index.md
@@ -1,0 +1,107 @@
+# 09c-A-production-deploy-execution
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | 9c-fu |
+| mode | serial |
+| owner | - |
+| 状態 | spec_created / docs-only / remaining-only |
+| visualEvidence | VISUAL |
+
+## purpose
+
+09c docs-only runbook を実 production deploy / smoke / 24h verification に進める。
+
+## why this is not a restored old task
+
+このタスクは完了済み本体タスクの復活ではなく、正本上で未実装・未実測として残った follow-up gate だけを扱う。
+
+09c は production release runbook specification として完了しているが、実 production deploy、D1 migration、release tag、runtime smoke、24h verification は user approval 後の別 operation として未実行である。
+
+## scope in / out
+
+### Scope In
+- user approval evidence
+- main merge commit と deploy target 照合
+- production D1 migration list/apply evidence
+- api/web production deploy evidence
+- release tag
+- production smoke
+- 24h verification
+
+### Scope Out
+- 09c docs-only 仕様書の再設計
+- 新規機能開発
+- secret 値の記録
+- 09a staging smoke 未完了時の production 実行
+
+## dependencies
+
+### Depends On
+- 09a staging smoke green
+- 09b release/incident runbook
+- 09b-B-cd-post-deploy-smoke-healthcheck（post-deploy healthcheck mechanism が green。silent failure 検知の前提）
+- 09b-A-observability-sentry-slack-runtime-smoke（runtime observability が疎通済み）
+- Phase 13 user approval
+
+### Blocks
+- post-release observation follow-ups
+
+## refs
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## AC
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+
+## completion definition
+
+全 phase 仕様書が揃い、実装・実測時の evidence path と user approval gate が明確であること。アプリケーションコード実装、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-01/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-01/main.md
@@ -1,0 +1,5 @@
+# outputs phase 01: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 要件定義
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-02/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-02/main.md
@@ -1,0 +1,5 @@
+# outputs phase 02: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 設計
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-03/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-03/main.md
@@ -1,0 +1,5 @@
+# outputs phase 03: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 設計レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-04/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-04/main.md
@@ -1,0 +1,5 @@
+# outputs phase 04: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: テスト戦略
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-05/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-05/main.md
@@ -1,0 +1,5 @@
+# outputs phase 05: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 実装ランブック
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-06/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-06/main.md
@@ -1,0 +1,5 @@
+# outputs phase 06: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 異常系検証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-07/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-07/main.md
@@ -1,0 +1,5 @@
+# outputs phase 07: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: AC マトリクス
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-08/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-08/main.md
@@ -1,0 +1,5 @@
+# outputs phase 08: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: DRY 化
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-09/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-09/main.md
@@ -1,0 +1,5 @@
+# outputs phase 09: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 品質保証
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-10/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-10/main.md
@@ -1,0 +1,5 @@
+# outputs phase 10: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 最終レビュー
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-11/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-11/main.md
@@ -1,0 +1,5 @@
+# outputs phase 11: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: 手動 smoke / 実測 evidence
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-12/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-12/main.md
@@ -1,0 +1,5 @@
+# outputs phase 12: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: ドキュメント更新
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-13/main.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/outputs/phase-13/main.md
@@ -1,0 +1,5 @@
+# outputs phase 13: 09c-A-production-deploy-execution
+
+- status: pending
+- purpose: PR 作成
+- evidence: to be captured during implementation/execution, not during spec creation.

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-01.md
@@ -1,0 +1,78 @@
+# Phase 1: 要件定義 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 1 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+未完了の真因、scope、依存境界、成功条件を確定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-02.md
@@ -1,0 +1,78 @@
+# Phase 2: 設計 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 2 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実行構造、evidence path、依存 matrix、rollback/skip 条件を設計する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 3 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+代替案、リスク、GO/NO-GO 条件をレビューする。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 4: テスト戦略 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 4 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+unit/contract/E2E/manual smoke/authorization の検証戦略を定義する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 5 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+コード実装または実行操作の runbook を定義する。実行自体はこの仕様書作成では行わない。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-06.md
@@ -1,0 +1,78 @@
+# Phase 6: 異常系検証 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 6 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+401/403/404/409/422/5xx、secret 不備、runtime drift、flaky を検証する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-07.md
@@ -1,0 +1,78 @@
+# Phase 7: AC マトリクス — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 7 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+AC と検証・evidence の対応表を作る。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-08.md
@@ -1,0 +1,78 @@
+# Phase 8: DRY 化 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 8 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+既存タスクとの重複、命名、evidence path、状態語彙を整理する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-09.md
@@ -1,0 +1,78 @@
+# Phase 9: 品質保証 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 9 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+free-tier、secret hygiene、a11y、運用リスクを確認する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-10.md
@@ -1,0 +1,78 @@
+# Phase 10: 最終レビュー — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 10 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+上流 gate と blocker を踏まえて GO/NO-GO を判定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-11.md
@@ -1,0 +1,78 @@
+# Phase 11: 手動 smoke / 実測 evidence — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 11 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+実測 evidence の取得手順と保存先を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-12.md
@@ -1,0 +1,78 @@
+# Phase 12: ドキュメント更新 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 12 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+正本仕様、workflow 状態、未タスク、skill feedback の更新方針を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — 09c-A-production-deploy-execution
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | 09c-A-production-deploy-execution |
+| phase | 13 / 13 |
+| wave | 9c-fu |
+| mode | serial |
+| 作成日 | 2026-05-01 |
+| taskType | implementation-spec / docs-only |
+| visualEvidence | VISUAL |
+
+## 目的
+
+commit / PR / deploy / production mutation の user approval gate を固定する。
+
+## 実行タスク
+
+1. 参照資料と親タスクの状態を確認する。完了条件: 未実装・未実測の境界が記録される。
+2. 本タスク固有の scope / AC / evidence を確認する。完了条件: AC と evidence path が対応する。
+3. user approval または上流 gate が必要な操作を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- docs/30-workflows/unassigned-task/task-09c-production-deploy-execution-001.md
+- docs/30-workflows/completed-tasks/09c-serial-production-deploy-and-post-release-verification/
+- docs/00-getting-started-manual/specs/15-infrastructure-runbook.md
+- .claude/skills/aiworkflow-requirements/references/deployment-cloudflare-opennext-workers.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/09c-A-production-deploy-execution/
+- 本仕様書作成ではアプリケーションコード、deploy、commit、push、PR 作成を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 09a staging smoke green, 09b release/incident runbook, Phase 13 user approval
+- 下流: post-release observation follow-ups
+
+## 多角的チェック観点
+
+- #5 public/member/admin boundary
+- #6 apps/web D1 direct access forbidden
+- #14 Cloudflare free-tier
+- 未実装/未実測を PASS と扱わない。
+- placeholder と実測 evidence を分離する。
+
+## サブタスク管理
+
+- [ ] refs を確認する
+- [ ] AC と evidence path を対応付ける
+- [ ] blocker / approval gate を明記する
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- user approval evidence が保存される
+- production D1 migration が Applied として確認される
+- api/web production deploy が exit 0
+- production public/member/admin smoke が green
+- release tag と 24h verification summary が保存される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく follow-up gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 完了 へ、AC、blocker、evidence path、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/_templates/naming-convention.md
+++ b/docs/30-workflows/02-application-implementation/_templates/naming-convention.md
@@ -1,0 +1,39 @@
+# Followup タスクディレクトリ命名規則
+
+## 形式
+`<親wave>-<実行順レター>-<topic-kebab-case>`
+
+例: `06b-A-me-api-authjs-session-resolver`
+
+## ルール
+
+1. **親wave**: 既存 wave 番号（`05a` `05b` `06a` `06b` `06c` `07a` `07b` `07c` `08a` `08b` `09a` `09b` `09c` `meta`）。新規 follow-up は所属する親 wave に従う。
+
+2. **実行順レター**: A から開始し、依存順に B、C、D... と進める。同じ親 wave 内で:
+   - A が最先行（他に依存しない or 親 wave 本体だけに依存）
+   - B は A の後続
+   - C は B の後続（必要なら）
+   - 真に並列実行可能でも sort 順を維持するため任意順で A/B/C... と振る
+
+3. **アルファベット順 = 実行順** の原則:
+   - `ls` で sort された結果がそのまま topological execution order になること
+   - クロス wave の場合: `06b-X` < `06c-Y`（lexicographic）なので 06b 系が先に完了してから 06c 系へ進む
+   - これにより `Depends On` / `Blocks` の整合とディレクトリ並びが自然に一致する
+
+4. **mode キーワードを名前に含めない**: 旧形式の `-parallel-` `-serial-` は廃止。並列可否は `Depends On` / `Blocks` でのみ判定する。
+
+5. **topic 部分**: kebab-case、`<役割>-<対象>-<動作>` の語順。3〜6 単語が目安。
+
+## アンチパターン
+
+- `06b-followup-001-parallel-...`（旧形式。`-followup-` `-parallel-` は禁止）
+- 数字枝番 `001/002`（sort 上は OK だが「並列だと誤解」を招くため非推奨）
+- 親 wave letter のスキップ（A → C のように B を飛ばさない）
+
+## 既存 wave との整合
+本規則は 2026-05-01 以降の new follow-up に適用。既存の親 wave（05a/05b/06a/06b/06c/...）のディレクトリ自体は本規則に該当せず、これまでのまま。
+
+## 参照
+- `_templates/task-index-template.md`: index.md 章立て
+- `_templates/artifacts-template.json`: artifacts.json スキーマ
+- `_templates/phase-template-app.md`: phase ファイル必須セクション

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/artifacts.json
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/artifacts.json
@@ -1,0 +1,112 @@
+{
+  "task": "meta-A-evidence-gate-dod-enforcement",
+  "status": "spec_created",
+  "createdAt": "2026-05-01",
+  "taskType": "governance-spec",
+  "docsOnly": true,
+  "scope": "governance",
+  "wave": "meta-fu",
+  "mode": "parallel",
+  "visualEvidence": "NON_VISUAL",
+  "depends_on": [
+    "05b-A-auth-mail-env-contract-alignment",
+    "05b-B-magic-link-callback-credentials-provider",
+    "06a-A-public-web-real-workers-d1-smoke-execution",
+    "06b-A-me-api-authjs-session-resolver",
+    "06b-B-profile-self-service-request-ui",
+    "06b-C-profile-logged-in-visual-evidence",
+    "06c-A-admin-dashboard",
+    "06c-B-admin-members",
+    "06c-C-admin-tags",
+    "06c-D-admin-schema",
+    "06c-E-admin-meetings",
+    "08a-A-public-use-case-coverage-hardening",
+    "08a-B-public-search-filter-coverage",
+    "08b-A-playwright-e2e-full-execution",
+    "09a-A-staging-deploy-smoke-execution",
+    "09b-A-observability-sentry-slack-runtime-smoke",
+    "09b-B-cd-post-deploy-smoke-healthcheck",
+    "09c-A-production-deploy-execution"
+  ],
+  "blocks": [],
+  "phases": [
+    {
+      "phase": "01",
+      "title": "要件定義",
+      "file": "phase-01.md",
+      "output": "outputs/phase-01/main.md"
+    },
+    {
+      "phase": "02",
+      "title": "設計",
+      "file": "phase-02.md",
+      "output": "outputs/phase-02/main.md"
+    },
+    {
+      "phase": "03",
+      "title": "設計レビュー",
+      "file": "phase-03.md",
+      "output": "outputs/phase-03/main.md"
+    },
+    {
+      "phase": "04",
+      "title": "テスト戦略",
+      "file": "phase-04.md",
+      "output": "outputs/phase-04/main.md"
+    },
+    {
+      "phase": "05",
+      "title": "実装ランブック",
+      "file": "phase-05.md",
+      "output": "outputs/phase-05/main.md"
+    },
+    {
+      "phase": "06",
+      "title": "異常系検証",
+      "file": "phase-06.md",
+      "output": "outputs/phase-06/main.md"
+    },
+    {
+      "phase": "07",
+      "title": "AC マトリクス",
+      "file": "phase-07.md",
+      "output": "outputs/phase-07/main.md"
+    },
+    {
+      "phase": "08",
+      "title": "DRY 化",
+      "file": "phase-08.md",
+      "output": "outputs/phase-08/main.md"
+    },
+    {
+      "phase": "09",
+      "title": "品質保証",
+      "file": "phase-09.md",
+      "output": "outputs/phase-09/main.md"
+    },
+    {
+      "phase": "10",
+      "title": "最終レビュー",
+      "file": "phase-10.md",
+      "output": "outputs/phase-10/main.md"
+    },
+    {
+      "phase": "11",
+      "title": "手動 smoke / 実測 evidence",
+      "file": "phase-11.md",
+      "output": "outputs/phase-11/main.md"
+    },
+    {
+      "phase": "12",
+      "title": "ドキュメント更新",
+      "file": "phase-12.md",
+      "output": "outputs/phase-12/main.md"
+    },
+    {
+      "phase": "13",
+      "title": "PR 作成",
+      "file": "phase-13.md",
+      "output": "outputs/phase-13/main.md"
+    }
+  ]
+}

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/index.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/index.md
@@ -1,0 +1,122 @@
+# meta-A-evidence-gate-dod-enforcement
+
+## wave / mode / owner
+
+| 項目 | 値 |
+| --- | --- |
+| wave | meta-fu |
+| mode | parallel |
+| owner | - |
+| 状態 | spec_created / docs-only / governance-meta |
+| visualEvidence | NON_VISUAL |
+
+## purpose
+
+本体タスクの close-out DoD に「real evidence captured (visual or runtime) OR follow-up issued」evidence gate を governance level で組み込み、本体タスクが docs-only / scaffold-only で `completed` 化することを構造的に防ぐ。task-specification-creator skill / CI workflow / lefthook の三層で gate を固定し、再発防止の正本仕様を確定する。
+
+## why this is not a restored old task
+
+このタスクは特定機能の実装・復活ではなく、過去 12 個の followup が発生した真因 = 本体タスクの DoD に evidence gate が無かったこと、への根治策である。
+
+`05b-B` 以下、`06a/06b/08a/08b/09a/09b/09c` に積み上がった followup は、いずれも「本体タスク完了時に visual / runtime evidence が NOT_EXECUTED placeholder のまま spec_created → completed が許容された」という同一構造から発生している。本タスクは個別機能を再実装するものではなく、close-out criteria を skill / CI / hook で固定して同種 followup の再発を防ぐ meta-control の仕様書である。
+
+## scope in / out
+
+### Scope In
+- task-specification-creator skill の Phase 12 / Phase 13 に evidence gate 定義を追記する spec
+- artifacts.json schema に `evidenceCaptured` / `followupIssued` 必須化の spec
+- `.github/workflows/` に evidence gate validator job 追加の spec
+- lefthook pre-push に軽量 evidence presence check 追加の spec
+- 本体タスクの completion definition に evidence OR followup の OR ゲート明記
+
+### Scope Out
+- skill 本体ファイル / workflow YAML / lefthook.yml への直接コード変更（本タスクは spec のみ）
+- 既存 18 followup（05b-A/B, 06a-A, 06b-A/B/C, 06c-A/B/C/D/E, 08a-A/B, 08b-A, 09a-A, 09b-A/B, 09c-A）の再仕様化
+- visual evidence 撮影フロー自体の再設計
+- secret 値や production endpoint の記録
+- 未承認 commit / push / PR
+
+## dependencies
+
+### Depends On
+- 05b-A / 05b-B
+- 06a-A
+- 06b-A / 06b-B / 06b-C
+- 06c-A / 06c-B / 06c-C / 06c-D / 06c-E
+- 08a-A / 08a-B / 08b-A
+- 09a-A / 09b-A / 09b-B / 09c-A
+- task-specification-creator skill
+- aiworkflow-requirements skill
+- `.github/workflows/verify-indexes.yml` の gate 設計（参考）
+
+### Blocks
+- future regression of "completed without evidence" pattern
+- 後続 wave での本体タスク close-out 時の DoD 不整合発生
+
+### 内部依存
+- skill spec 更新と CI validator 追加と lefthook 追加は独立 PR で着手可能（parallel）。本仕様書は 3 層を 1 タスクで束ねて governance gate 全体像を確定する。
+
+## refs
+
+- .claude/skills/task-specification-creator/SKILL.md
+- .claude/skills/task-specification-creator/references/phase-12-spec.md
+- .claude/skills/aiworkflow-requirements/
+- docs/30-workflows/02-application-implementation/_templates/task-index-template.md
+- docs/30-workflows/02-application-implementation/_templates/phase-template-app.md
+- docs/30-workflows/02-application-implementation/_templates/phase-meaning-app.md
+- docs/30-workflows/02-application-implementation/_templates/artifacts-template.json
+- docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/
+- .github/workflows/verify-indexes.yml
+- lefthook.yml
+
+## AC
+
+- task-specification-creator skill の Phase 12 / 13 spec に evidence gate 判定基準が明記される
+- artifacts.json schema に `evidenceCaptured` / `followupIssued` フィールドの必須化方針が記載される
+- CI validator job の入出力契約（artifacts.json 参照、outputs/phase-11/ 走査、followup ref 検査）が spec として固まる
+- lefthook pre-push の opt-in evidence presence check の責務境界が明記される
+- `visualEvidence == "VISUAL"` 時は `outputs/phase-11/` に screenshot 系成果物 1 件以上、`NON_VISUAL` 時は curl/wrangler 等の runtime evidence、いずれも欠落時は対応 followup タスク参照が必須、というルールが文書化される
+- spec のみで完結し、skill / workflow / hook ファイルの直接変更を含まない
+
+## 13 phases
+
+- [phase-01.md](phase-01.md) — 要件定義
+- [phase-02.md](phase-02.md) — 設計
+- [phase-03.md](phase-03.md) — 設計レビュー
+- [phase-04.md](phase-04.md) — テスト戦略
+- [phase-05.md](phase-05.md) — 実装ランブック
+- [phase-06.md](phase-06.md) — 異常系検証
+- [phase-07.md](phase-07.md) — AC マトリクス
+- [phase-08.md](phase-08.md) — DRY 化
+- [phase-09.md](phase-09.md) — 品質保証
+- [phase-10.md](phase-10.md) — 最終レビュー
+- [phase-11.md](phase-11.md) — 手動 smoke / 実測 evidence
+- [phase-12.md](phase-12.md) — ドキュメント更新
+- [phase-13.md](phase-13.md) — PR 作成
+
+## outputs
+
+- outputs/phase-01/main.md
+- outputs/phase-02/main.md
+- outputs/phase-03/main.md
+- outputs/phase-04/main.md
+- outputs/phase-05/main.md
+- outputs/phase-06/main.md
+- outputs/phase-07/main.md
+- outputs/phase-08/main.md
+- outputs/phase-09/main.md
+- outputs/phase-10/main.md
+- outputs/phase-11/main.md
+- outputs/phase-12/main.md
+- outputs/phase-13/main.md
+
+## invariants touched
+
+- skill governance（task-specification-creator の Phase 12 / 13 仕様）
+- audit traceability（artifacts.json と outputs/phase-11/ の対応関係）
+- close-out DoD 不変条件（spec_created → completed without evidence の禁止）
+- CI gate 一貫性（verify-indexes と evidence gate の整合）
+
+## completion definition
+
+全 13 phase 仕様書、index.md、artifacts.json が揃い、skill / CI / lefthook 三層に対する evidence gate spec の境界、入出力契約、approval gate が明記されていること。skill 本体・workflow YAML・lefthook.yml の直接コード変更、deploy、commit、push、PR 作成はこの仕様書作成タスクには含めない。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-01.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-01.md
@@ -1,0 +1,81 @@
+# Phase 1: 要件定義 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 1 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+evidence gate を導入する真因、scope、依存境界、成功条件を確定する。本タスクが「12 followup を生んだ DoD の構造欠陥」をどう塞ぐかを文書として固定する。
+
+## 実行タスク
+
+1. 12 個の既存 followup の発生原因を整理する。完了条件: 「evidence 欠落 → completed 化」共通パターンが明示される。
+2. evidence gate の対象 layer (skill / CI / hook) と責務分担を確認する。完了条件: 三層の境界が記録される。
+3. user approval が必要な操作（skill 本体変更、workflow 追加）を分離する。完了条件: 自走禁止操作が明記される。
+
+## 参照資料
+
+- .claude/skills/task-specification-creator/SKILL.md
+- .claude/skills/task-specification-creator/references/phase-12-spec.md
+- docs/30-workflows/02-application-implementation/_templates/task-index-template.md
+- docs/30-workflows/02-application-implementation/_templates/artifacts-template.json
+- docs/30-workflows/02-application-implementation/06b-A-me-api-authjs-session-resolver/index.md
+- .github/workflows/verify-indexes.yml
+- lefthook.yml
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 本仕様書作成では skill 本体、workflow YAML、lefthook.yml への直接変更を行わない。
+- 実装・実測時は Phase 5 / Phase 11 の runbook と evidence path に従う。
+
+## 統合テスト連携
+
+- 上流: 既存 12 followup タスク群、task-specification-creator skill, aiworkflow-requirements skill
+- 下流: 後続 wave の本体タスクすべての close-out DoD
+
+## 多角的チェック観点
+
+- skill governance（Phase 12 / 13 spec の整合）
+- audit traceability（artifacts.json と outputs/phase-11/ の対応）
+- close-out DoD（spec_created → completed の遷移条件）
+- CI gate 一貫性（verify-indexes と evidence gate の責務分離）
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結し、実コードに踏み込まない
+
+## サブタスク管理
+
+- [ ] 12 followup の根本原因を 1 行ずつ整理する
+- [ ] evidence gate 三層の責務境界を表形式で記録する
+- [ ] approval gate / blocker を明記する
+- [ ] outputs/phase-01/main.md を作成する
+
+## 成果物
+
+- outputs/phase-01/main.md
+
+## 完了条件
+
+- evidence gate の対象 layer と責務が確定する
+- AC が「skill spec / CI validator spec / lefthook spec」の三本柱で表現される
+- VISUAL / NON_VISUAL いずれの evidence 欠落も「followup issued」で代替可能な OR ゲートが明記される
+- 本タスクが governance-spec / docs-only であることが明示される
+
+## タスク100%実行確認
+
+- [ ] この Phase の必須セクションがすべて埋まっている
+- [ ] 完了済み本体タスクの復活ではなく meta-control gate の仕様になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 2 へ、AC、blocker、evidence path、approval gate、三層責務境界を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-02.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-02.md
@@ -1,0 +1,79 @@
+# Phase 2: 設計 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 2 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+evidence gate を skill / CI / lefthook の三層でどのように構成するか、各層の入出力契約と判定アルゴリズムを設計する。
+
+## 実行タスク
+
+1. skill 層 (task-specification-creator Phase 12 / 13 spec) の追記項目を設計する。完了条件: gate 判定アルゴリズム pseudocode が記述される。
+2. CI 層 (validator job) の入力 (artifacts.json, outputs/phase-11/, 関連 followup ref) と出力 (job 成否) を設計する。完了条件: 入出力契約が表で固定される。
+3. lefthook 層 (pre-push opt-in check) の責務範囲と skip 条件を設計する。完了条件: CI と lefthook の責務重複が排除される。
+
+## 参照資料
+
+- .claude/skills/task-specification-creator/SKILL.md
+- .claude/skills/task-specification-creator/references/phase-12-spec.md
+- docs/30-workflows/02-application-implementation/_templates/artifacts-template.json
+- .github/workflows/verify-indexes.yml
+- lefthook.yml
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 設計記述は spec 文書のみ。skill / workflow / hook の正本ファイルには触れない。
+- 三層は独立 PR で実装可能な責務分離とする。
+
+## 統合テスト連携
+
+- 上流: Phase 1 で確定した三層責務境界、AC、approval gate
+- 下流: Phase 3 設計レビュー、Phase 4 テスト戦略
+
+## 多角的チェック観点
+
+- skill governance（Phase 12 / 13 spec 追記の整合）
+- audit traceability（artifacts.json schema 拡張の後方互換）
+- CI gate 一貫性（既存 verify-indexes と機能重複しない）
+- lefthook 軽量性（pre-push を遅延させない）
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] skill 層の追記項目と pseudocode を記述
+- [ ] CI 層の入出力契約表を作成
+- [ ] lefthook 層の skip 条件を記述
+- [ ] outputs/phase-02/main.md を作成する
+
+## 成果物
+
+- outputs/phase-02/main.md
+
+## 完了条件
+
+- 三層それぞれに入力 / 判定 / 出力の契約が記述される
+- artifacts.json schema 拡張案が後方互換であることが示される
+- VISUAL / NON_VISUAL / followup issued の三分岐すべてに gate 設計が対応する
+- 既存 verify-indexes gate との責務重複がないことが明記される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 三層が独立 PR で実装可能な責務分離になっている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 3 へ、三層設計、入出力契約、判定アルゴリズム pseudocode を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-03.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-03.md
@@ -1,0 +1,78 @@
+# Phase 3: 設計レビュー — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 3 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+Phase 2 設計が「12 followup の真因」を構造的に塞ぐかを 4 条件 (矛盾なし / 漏れなし / 整合性 / 依存関係) で検証する。
+
+## 実行タスク
+
+1. 設計が VISUAL / NON_VISUAL / followup issued の三分岐を漏れなくカバーするかを検証する。完了条件: カバレッジ表が記録される。
+2. skill / CI / lefthook 三層間の判定矛盾がないかを確認する。完了条件: 矛盾検出 0 件、もしくは検出時の解消方針が明記される。
+3. solo 開発ポリシー (required_pull_request_reviews=null) との整合を確認する。完了条件: governance 上の競合がないことが記録される。
+
+## 参照資料
+
+- Phase 2 設計文書
+- CLAUDE.md (Branch / Governance section)
+- .github/CODEOWNERS
+- .claude/skills/task-specification-creator/references/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 仕様書のみ更新。skill / workflow / hook の正本に触れない。
+- 矛盾検出時は Phase 2 へ feedback、Phase 4 以降には進めない。
+
+## 統合テスト連携
+
+- 上流: Phase 2 設計、三層責務境界
+- 下流: Phase 4 テスト戦略
+
+## 多角的チェック観点
+
+- skill governance との整合
+- audit traceability（artifacts.json と outputs の往復）
+- CI gate と branch protection の整合
+- solo 運用ポリシー（review 不要）との整合
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] 三分岐カバレッジ表を作成
+- [ ] 三層判定矛盾チェック結果を記録
+- [ ] solo policy 整合確認結果を記録
+- [ ] outputs/phase-03/main.md を作成する
+
+## 成果物
+
+- outputs/phase-03/main.md
+
+## 完了条件
+
+- 三分岐すべてに gate 判定が割り当てられている
+- skill / CI / lefthook 間の判定矛盾が 0 件
+- solo 運用ポリシーとの競合がない
+- 検出された懸念は Phase 2 への feedback ループとして記録される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 4 条件 (矛盾なし / 漏れなし / 整合性 / 依存関係) で検証している
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 4 へ、検証済み設計、三層責務境界、矛盾解消方針を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-04.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-04.md
@@ -1,0 +1,76 @@
+# Phase 4: テスト戦略 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 4 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+evidence gate spec が将来コード化された際に検証可能な test 観点を、spec 段階で確定する。
+
+## 実行タスク
+
+1. CI validator job の unit / contract test 観点を列挙する。完了条件: VISUAL / NON_VISUAL / followup-issued / missing の 4 ケースが記録される。
+2. lefthook hook の skip / fail / pass パターンの test 観点を列挙する。完了条件: merge-commit skip / 通常 push / evidence 欠落の各ケースが記録される。
+3. skill spec の互換性検証観点を列挙する。完了条件: 既存 followup タスクが retroactively fail しないことを確認する観点が記録される。
+
+## 参照資料
+
+- Phase 2 設計、Phase 3 レビュー結果
+- .github/workflows/verify-indexes.yml
+- lefthook.yml
+- 既存 12 followup タスク群
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- spec のみ。test コードは書かない。
+
+## 統合テスト連携
+
+- 上流: Phase 3 検証済み設計
+- 下流: Phase 5 実装ランブック、Phase 11 evidence
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability
+- CI gate retroactive 互換性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] CI validator の 4 ケース test 観点を列挙
+- [ ] lefthook の 3 パターン test 観点を列挙
+- [ ] skill spec 互換性観点を列挙
+- [ ] outputs/phase-04/main.md を作成する
+
+## 成果物
+
+- outputs/phase-04/main.md
+
+## 完了条件
+
+- VISUAL / NON_VISUAL / followup-issued / missing の 4 ケースが test 観点に含まれる
+- 既存 12 followup が gate により retroactively fail しないことを確認する観点が含まれる
+- merge commit / sync-merge 中の skip 条件が test 観点に含まれる
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] test 観点が三層すべてをカバーしている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 5 へ、test 観点リスト、retroactive 互換性条件、skip 条件を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-05.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-05.md
@@ -1,0 +1,78 @@
+# Phase 5: 実装ランブック — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 5 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+将来 spec を実コードに反映する際の手順を、独立 PR 単位で 3 本のランブックとして固定する。本タスク自体ではコード変更を行わない。
+
+## 実行タスク
+
+1. PR-A (skill spec 更新) のランブックを記述する。完了条件: 対象ファイル、追記内容の要点、approval gate が明記される。
+2. PR-B (CI validator job 追加) のランブックを記述する。完了条件: workflow ファイル名、trigger 条件、failing 例外処理が明記される。
+3. PR-C (lefthook pre-push opt-in check 追加) のランブックを記述する。完了条件: hook 名、skip 条件、opt-in env 変数が明記される。
+
+## 参照資料
+
+- Phase 2 設計、Phase 4 test 観点
+- .claude/skills/task-specification-creator/references/
+- .github/workflows/
+- lefthook.yml
+- CLAUDE.md (sync-merge hook policy)
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 本タスク内では runbook を spec 化するのみ。コード変更は別 PR / 別タスクで実行する。
+- 3 PR は parallel 着手可能。マージ順は skill → CI → lefthook 推奨。
+
+## 統合テスト連携
+
+- 上流: Phase 4 test 観点
+- 下流: Phase 6 異常系、Phase 11 evidence
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability
+- CI gate 一貫性
+- lefthook 軽量性、sync-merge skip 整合
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] PR-A skill spec runbook を記述
+- [ ] PR-B CI validator runbook を記述
+- [ ] PR-C lefthook runbook を記述
+- [ ] outputs/phase-05/main.md を作成する
+
+## 成果物
+
+- outputs/phase-05/main.md
+
+## 完了条件
+
+- 3 PR の対象ファイル、変更要点、approval gate が runbook として固定される
+- 推奨マージ順が記載される
+- 各 PR 単独で revert 可能な切り出しになっている
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 3 PR が独立 revertable に切り出されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 6 へ、3 PR runbook、approval gate、推奨マージ順を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-06.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-06.md
@@ -1,0 +1,75 @@
+# Phase 6: 異常系検証 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 6 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+evidence gate が誤判定 / 過剰検出 / バイパスされる異常系を spec 段階で列挙し、対応方針を確定する。
+
+## 実行タスク
+
+1. false positive 異常系を列挙する。完了条件: 「evidence は揃っているが gate が fail する」シナリオと回避策が記録される。
+2. false negative 異常系を列挙する。完了条件: 「evidence が無いのに gate が pass する」シナリオと検出策が記録される。
+3. bypass 異常系を列挙する。完了条件: `--no-verify` / artifacts.json 改ざん / outputs/ の placeholder 復活、への対処方針が記録される。
+
+## 参照資料
+
+- Phase 5 runbook
+- CLAUDE.md（`--no-verify` 禁止ポリシー）
+- lefthook.yml（既存 hook の skip パターン）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- spec のみ。実コードでの異常系再現は本タスクには含めない。
+
+## 統合テスト連携
+
+- 上流: Phase 5 runbook
+- 下流: Phase 7 AC マトリクス
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability（改ざん検知）
+- CI gate retroactive 互換性
+- lefthook bypass 不可能性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] false positive シナリオと回避策を列挙
+- [ ] false negative シナリオと検出策を列挙
+- [ ] bypass シナリオと対処方針を列挙
+- [ ] outputs/phase-06/main.md を作成する
+
+## 成果物
+
+- outputs/phase-06/main.md
+
+## 完了条件
+
+- false positive / false negative / bypass の 3 区分すべてに最低 1 件のシナリオが列挙される
+- bypass シナリオには `--no-verify` 禁止ポリシーと audit log の整合策が含まれる
+- sync-merge hook skip との整合が記録される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 3 区分の異常系がすべてカバーされている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 7 へ、異常系シナリオ、対処方針、bypass 禁止条件を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-07.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-07.md
@@ -1,0 +1,74 @@
+# Phase 7: AC マトリクス — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 7 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+index.md の AC を、Phase 1〜6 で確定した三層 spec / test 観点 / 異常系 / runbook と紐づけ、抜け漏れを排除する。
+
+## 実行タスク
+
+1. AC ↔ Phase 出力のトレーサビリティ表を作成する。完了条件: 各 AC が Phase 02 / 04 / 05 / 06 のどの章で担保されるかが特定される。
+2. 未紐付け AC または未紐付け Phase 出力を検出する。完了条件: 抜け漏れ 0、もしくは Phase 戻し計画が記載される。
+3. retroactive 互換性 (既存 12 followup が現状 fail しない) が AC として明記されているかを確認する。完了条件: 該当 AC が確認される、または追記される。
+
+## 参照資料
+
+- index.md (AC セクション)
+- Phase 02 / 04 / 05 / 06 出力
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- spec のみ。
+
+## 統合テスト連携
+
+- 上流: Phase 2〜6
+- 下流: Phase 8 DRY 化
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability
+- CI gate retroactive 互換性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] AC ↔ Phase 出力対応表を作成
+- [ ] 抜け漏れ検出結果を記録
+- [ ] retroactive 互換性 AC を確認
+- [ ] outputs/phase-07/main.md を作成する
+
+## 成果物
+
+- outputs/phase-07/main.md
+
+## 完了条件
+
+- 全 AC が Phase 出力に紐付く
+- 抜け漏れ 0、もしくは Phase 戻し計画が明記される
+- retroactive 互換性 AC が含まれる
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 抜け漏れ 0 が確認されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 8 へ、AC トレーサビリティ表、未紐付け対応計画を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-08.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-08.md
@@ -1,0 +1,74 @@
+# Phase 8: DRY 化 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 8 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+skill / CI / lefthook 三層の spec で重複している判定ロジックを単一定義に集約する。
+
+## 実行タスク
+
+1. 三層共通の「evidence presence 判定」を skill spec の references/ 1 ファイルに集約する spec を記述する。完了条件: CI / lefthook はこの単一定義を参照する旨が明記される。
+2. artifacts.json schema 拡張を 1 ファイルに集約する spec を記述する。完了条件: schema 二重定義が排除される。
+3. followup ref フォーマット (どの directory 名規約で followup と認定するか) を 1 ファイルに集約する。完了条件: 三層がこの規約を参照する。
+
+## 参照資料
+
+- Phase 2 設計、Phase 7 AC マトリクス
+- .claude/skills/task-specification-creator/references/
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 集約は spec 上の参照関係宣言のみ。実ファイル統合は別 PR で実施。
+
+## 統合テスト連携
+
+- 上流: Phase 7 AC マトリクス
+- 下流: Phase 9 品質保証
+
+## 多角的チェック観点
+
+- skill governance（単一情報源）
+- audit traceability
+- CI gate 一貫性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] evidence 判定単一定義 spec を記述
+- [ ] artifacts.json schema 集約 spec を記述
+- [ ] followup ref 規約集約 spec を記述
+- [ ] outputs/phase-08/main.md を作成する
+
+## 成果物
+
+- outputs/phase-08/main.md
+
+## 完了条件
+
+- 三層共通の判定ロジックが単一定義に集約される
+- artifacts.json schema 拡張が 1 箇所に集約される
+- followup ref 規約が 1 箇所に集約される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 重複定義が排除されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 9 へ、単一定義参照表、集約済み schema spec を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-09.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-09.md
@@ -1,0 +1,75 @@
+# Phase 9: 品質保証 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 9 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+spec 全体に対して typecheck / lint 相当の整合確認を行い、文書としての品質を保証する。
+
+## 実行タスク
+
+1. index.md / artifacts.json / phase-01〜13 のメタ情報整合 (wave / mode / taskType / visualEvidence) を確認する。完了条件: drift 0。
+2. 参照ファイルパスが実在することを確認する。完了条件: 全パス resolvable、もしくは備考付きで未存在を許容する根拠が記録される。
+3. AC・完了条件・runbook が「spec のみ・コード変更なし」原則を破っていないかを確認する。完了条件: 違反 0。
+
+## 参照資料
+
+- index.md
+- artifacts.json
+- phase-01〜phase-13.md
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- spec のみ。
+
+## 統合テスト連携
+
+- 上流: Phase 8 DRY 化
+- 下流: Phase 10 最終レビュー
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability
+- CI gate 一貫性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] メタ情報 drift 検査
+- [ ] 参照パス実在確認
+- [ ] spec-only 原則遵守確認
+- [ ] outputs/phase-09/main.md を作成する
+
+## 成果物
+
+- outputs/phase-09/main.md
+
+## 完了条件
+
+- メタ情報 drift 0
+- 参照パス未解決 0、または許容根拠が記録される
+- spec-only 原則違反 0
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] drift / 違反 0 が確認されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 10 へ、整合確認結果、未解決事項リストを渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-10.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-10.md
@@ -1,0 +1,75 @@
+# Phase 10: 最終レビュー — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 10 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+Phase 1〜9 を通じて得た成果を「12 followup 真因 → evidence gate spec」というストーリーで再俯瞰し、未対応の懸念を可視化する。
+
+## 実行タスク
+
+1. 真因 → 設計 → AC → runbook → 異常系 → DRY → QA の連鎖が一貫しているかを確認する。完了条件: 断絶箇所 0、もしくは追記計画が記載される。
+2. solo 開発ポリシー / sync-merge hook skip / `--no-verify` 禁止ポリシーとの最終整合を確認する。完了条件: 競合 0。
+3. 後続 wave の本体タスクが本 spec を参照するためのリンク配置 (master-task-list 等) を提案する。完了条件: 配置案が記載される。
+
+## 参照資料
+
+- Phase 1〜9 出力
+- CLAUDE.md
+- docs/30-workflows/00-master-task-list.md（存在すれば）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- spec のみ。
+
+## 統合テスト連携
+
+- 上流: Phase 1〜9 全出力
+- 下流: Phase 11 evidence、Phase 12 docs
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability
+- CI gate 一貫性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] 連鎖一貫性確認
+- [ ] policy 整合確認
+- [ ] 参照リンク配置案を記述
+- [ ] outputs/phase-10/main.md を作成する
+
+## 成果物
+
+- outputs/phase-10/main.md
+
+## 完了条件
+
+- ストーリー連鎖の断絶 0
+- policy 競合 0
+- 後続 wave の参照リンク配置案が記載される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 連鎖一貫性が確認されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 11 へ、最終レビュー結果、未対応懸念、参照リンク配置案を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-11.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-11.md
@@ -1,0 +1,75 @@
+# Phase 11: 手動 smoke / 実測 evidence — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 11 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+本タスクは spec のみであり実行可能な runtime evidence を持たない。代替として「spec 文書としての evidence」(全 phase 出力の存在 / 文書整合) を確認する手順を確定する。
+
+## 実行タスク
+
+1. outputs/phase-01/main.md 〜 outputs/phase-10/main.md の存在確認手順を記述する。完了条件: 確認コマンドが明記される。
+2. `meta-evidence-gate` の dogfooding として、本タスク自身が evidence gate spec を満たしているかをチェックする観点を記述する。完了条件: self-check 観点が記録される。
+3. user approval が必要な操作 (skill / workflow / lefthook 実コード変更) を「本タスクで実施しない」旨を明記する。完了条件: 自走禁止操作が再確認される。
+
+## 参照資料
+
+- outputs/phase-01〜10/main.md
+- Phase 8 で集約した evidence 判定単一定義 spec
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- spec のみ。runtime evidence の収集は対象外（NON_VISUAL かつ spec-only タスク）。
+- 後続でコード化される際は別タスクで evidence を収集する。
+
+## 統合テスト連携
+
+- 上流: Phase 10 最終レビュー
+- 下流: Phase 12 docs、Phase 13 PR
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability（spec 文書としての完全性）
+- CI gate 一貫性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する（dogfooding として本タスクは「followup issued」分岐ではなく「NON_VISUAL spec evidence」分岐に該当）
+
+## サブタスク管理
+
+- [ ] 全 phase 出力の存在確認手順を記述
+- [ ] self-check 観点を記述
+- [ ] 自走禁止操作を再確認
+- [ ] outputs/phase-11/main.md を作成する
+
+## 成果物
+
+- outputs/phase-11/main.md
+
+## 完了条件
+
+- 全 phase 出力の存在確認手順が明記される
+- 本タスク自身が dogfooding として evidence gate spec を満たすことが確認される
+- 自走禁止操作が再確認される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] dogfooding self-check が記録されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 12 へ、self-check 結果、自走禁止操作リストを渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-12.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-12.md
@@ -1,0 +1,95 @@
+# Phase 12: ドキュメント更新 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 12 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+正本仕様、runbook、lessons learned に「evidence gate」概念を追記し、後続 wave の本体タスクが本仕様を参照できるようにする。
+
+## 中学生レベル概念説明（このタスクの肝を平易に）
+
+「タスクが終わった」と「タスクが本当に終わった」は違う、という話を、宿題の例で説明する。
+
+- 学校の先生に「宿題やりました！」と口で言うだけでは、本当にやったかどうか分からない。
+- ノートを開いて、書いてあるページを見せて、初めて「ちゃんとやった」と認められる。
+- もしまだ書けていないページがあったら、「来週までに出します」と紙に書いて先生に渡す。これが「未提出宿題リスト」(= followup) になる。
+
+evidence gate は、この「ノートを見せる or 未提出リストを出す」を、タスクの完了条件としてシステムに固定する仕組みである。
+
+| 学校の宿題 | このプロジェクトでの対応 |
+| --- | --- |
+| 「宿題やりました！」と口で言う | artifacts.json の status を completed にする |
+| ノートを開いて見せる | outputs/phase-11/ に screenshot や curl ログを置く (= real evidence) |
+| 未提出ページの紙を出す | followup タスク directory を発行する |
+| 先生がノートも紙も無いと気づいて差し戻す | CI validator job が fail する / lefthook が止める |
+
+つまり「言うだけで終わった事にする」ことを構造的に禁止し、「証拠を見せる」か「未提出リストを書く」かの二択を強制する。これが evidence gate である。
+
+## 実行タスク
+
+1. task-specification-creator skill の references/ に evidence gate 章を追加する spec を記述する。完了条件: 追記対象ファイル名と章タイトルが明記される。
+2. CLAUDE.md の close-out 関連セクションに「evidence OR followup」一文を追記する spec を記述する。完了条件: 追記場所と一文が記録される。
+3. lessons learned として「12 followup 連鎖はなぜ起きたか」を追記する spec を記述する。完了条件: 真因と対策の対応表が記録される。
+
+## 参照資料
+
+- .claude/skills/task-specification-creator/references/
+- CLAUDE.md
+- docs/30-workflows/02-application-implementation/_templates/
+- 既存 12 followup タスク群（lessons learned source）
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 本タスクは追記内容を spec として固定する。実ファイル更新は別 PR で実施。
+
+## 統合テスト連携
+
+- 上流: Phase 11 self-check
+- 下流: Phase 13 PR 作成
+
+## 多角的チェック観点
+
+- skill governance（references/ 章追加の整合）
+- audit traceability（lessons learned が真因に対応）
+- CI gate 一貫性
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] skill references/ 追記 spec を記述
+- [ ] CLAUDE.md 追記 spec を記述
+- [ ] lessons learned spec を記述
+- [ ] outputs/phase-12/main.md を作成する
+
+## 成果物
+
+- outputs/phase-12/main.md
+
+## 完了条件
+
+- skill references/ 追記対象と章タイトルが固定される
+- CLAUDE.md 追記場所と一文が固定される
+- 12 followup 真因 ↔ evidence gate 対策の対応表が記録される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 中学生レベル概念説明と日常例えが含まれている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+Phase 13 へ、追記対象リスト、lessons learned、approval gate を渡す。

--- a/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-13.md
+++ b/docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/phase-13.md
@@ -1,0 +1,78 @@
+# Phase 13: PR 作成 — meta-A-evidence-gate-dod-enforcement
+
+## メタ情報
+
+| 項目 | 値 |
+| --- | --- |
+| task name | meta-A-evidence-gate-dod-enforcement |
+| phase | 13 / 13 |
+| wave | meta-fu |
+| mode | parallel |
+| 作成日 | 2026-05-01 |
+| taskType | governance-spec / docs-only |
+| visualEvidence | NON_VISUAL |
+
+## 目的
+
+本仕様書 directory を PR としてまとめるための手順を spec 化する。本タスク内では PR 作成自体は行わず、commit / push / PR は user approval 後に別 phase で実行する。
+
+## 実行タスク
+
+1. PR タイトル / body / labels の draft を spec 化する。完了条件: 70 文字以内のタイトル、Summary / Test plan の body 構造が明記される。
+2. 含めるファイル一覧を spec 化する。完了条件: 15 ファイル (index.md / artifacts.json / phase-01〜13.md) が列挙される。
+3. user approval gate と branch protection 整合を確認する spec を記述する。完了条件: solo policy / required_status_checks との整合が明記される。
+
+## 参照資料
+
+- index.md
+- artifacts.json
+- phase-01.md 〜 phase-12.md
+- CLAUDE.md (Branch / Governance section)
+
+## 実行手順
+
+- 対象 directory: docs/30-workflows/02-application-implementation/meta-A-evidence-gate-dod-enforcement/
+- 本タスク内では PR 作成、commit、push を行わない。
+- spec が示す手順に従って、後続作業として user approval 後に PR 作成する。
+
+## 統合テスト連携
+
+- 上流: Phase 12 docs
+- 下流: 後続 wave の本体タスク close-out で本仕様参照
+
+## 多角的チェック観点
+
+- skill governance
+- audit traceability（PR ↔ spec ↔ artifacts.json の整合）
+- CI gate 一貫性（required_status_checks が pass する）
+- lefthook 軽量性
+- 未実装/未実測を PASS と扱わない
+- spec のみで完結する
+
+## サブタスク管理
+
+- [ ] PR タイトル / body / labels draft を記述
+- [ ] 含めるファイル 15 件を列挙
+- [ ] approval gate / branch protection 整合を記述
+- [ ] outputs/phase-13/main.md を作成する
+
+## 成果物
+
+- outputs/phase-13/main.md
+
+## 完了条件
+
+- PR タイトル 70 文字以内、body は Summary / Test plan の二章構造で固定される
+- 含めるファイル 15 件 (index.md / artifacts.json / phase-01〜13.md) が列挙される
+- user approval 前に commit / push / PR を実行しない旨が明記される
+- solo policy (required_pull_request_reviews=null) と CI gate との整合が明記される
+
+## タスク100%実行確認
+
+- [ ] 必須セクションがすべて埋まっている
+- [ ] 15 ファイルが列挙されている
+- [ ] 実装、deploy、commit、push、PR を実行していない
+
+## 次 Phase への引き渡し
+
+本仕様書作成タスクはこの phase で完了。後続の実コード化 (skill / CI / lefthook 各 PR) は Phase 5 runbook を参照する別タスクで実施する。


### PR DESCRIPTION
## Summary
- Application Implementation フェーズの follow-up タスク 20 件を Phase 1-13 仕様書として追加（442 ファイル / +27,008 行）
- 領域: auth (05b A/B), public web smoke (06a A), profile/me (06b A-C), admin (06c A-E), public coverage (08a A/B), e2e (08b A), deploy (09a A / 09b A-B / 09c A), evidence gate (meta-A)
- 各タスクは単一責務原則で分解、並列実行可能な構成（`task-specification-creator` skill 準拠）

## 変更内容
- `docs/30-workflows/02-application-implementation/` 配下に 20 タスクディレクトリを新設
  - 各ディレクトリに `index.md` / `artifacts.json` / `phase-01.md`〜`phase-13.md` / `outputs/phase-XX/main.md` を含む
- `_templates/naming-convention.md` を追加（命名規約の正本化）

## 領域別タスク一覧
| 領域 | タスク |
|------|--------|
| Auth/Mail | 05b-A-auth-mail-env-contract-alignment, 05b-B-magic-link-callback-credentials-provider |
| Public Web Smoke | 06a-A-public-web-real-workers-d1-smoke-execution |
| Profile/Me | 06b-A-me-api-authjs-session-resolver, 06b-B-profile-self-service-request-ui, 06b-C-profile-logged-in-visual-evidence |
| Admin | 06c-A-admin-dashboard, 06c-B-admin-members, 06c-C-admin-tags, 06c-D-admin-schema, 06c-E-admin-meetings |
| Public Coverage | 08a-A-public-use-case-coverage-hardening, 08a-B-public-search-filter-coverage |
| E2E | 08b-A-playwright-e2e-full-execution |
| Deploy/Observability | 09a-A-staging-deploy-smoke-execution, 09b-A-observability-sentry-slack-runtime-smoke, 09b-B-cd-post-deploy-smoke-healthcheck, 09c-A-production-deploy-execution |
| Meta | meta-A-evidence-gate-dod-enforcement |

## 品質検証
- [x] `pnpm install --force` PASS
- [x] `pnpm typecheck` PASS（5 packages）
- [x] `pnpm lint` PASS（boundaries + 5 packages）

## Test plan
- [ ] CI gate（typecheck / lint / verify-indexes / boundaries）が PASS すること
- [ ] docs-only 変更のため runtime 影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)