### PR TITLE
chore(hooks): generalize stale-worktree-notice to main/dev and add sync:check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ mise exec -- pnpm typecheck       # 型チェック
 mise exec -- pnpm lint            # リント
 mise exec -- pnpm build           # ビルド
 mise exec -- pnpm indexes:rebuild # skill indexes を明示再生成（post-merge 廃止後の正規経路）
+mise exec -- pnpm sync:check      # origin/main・origin/dev とローカル/全 worktree の遅れを通知（git fetch 後の手動チェック）
 
 # または mise shell で Node 24 環境に入ってから通常通り実行
 mise shell
@@ -177,6 +178,18 @@ main を feature ブランチへ取り込む sync-merge では、構造的に「
 | pre-push `coverage-guard` | push 範囲 (`@{u}..HEAD`) に merge commit を 1 件以上含む かつ `--changed` モード時 | `scripts/coverage-guard.sh` |
 
 これにより main 取り込み時の `git commit` / `git push` で `--no-verify` を**付ける必要はない**。featureコミット/pushは従来通りhookが効く。`--no-verify` の使用は引き続き避け、hook が誤検知する場合は本セクションの方針に沿って hook 自体を改善すること。
+
+### リモート同期チェック (`pnpm sync:check`) — main / dev 共通
+
+git には `post-fetch` hook が存在しないため、`git fetch` 後にリモートの遅れを自動通知する仕組みは原理的に作れない。代わりに **手動コマンド `pnpm sync:check`** を正規経路とする。
+
+| モード | 発火タイミング | 対象 |
+|-------|----------------|------|
+| `pnpm sync:check`（fetch モード） | 任意のタイミングで手動実行 | `origin/main` / `origin/dev` の先行コミット数、全 worktree の遅れ |
+| `post-merge` フック | `git pull` / `git merge` 後、現在ブランチが `main` または `dev` のとき | 他 worktree の遅れを通知 |
+
+実装: `scripts/hooks/stale-worktree-notice.sh`（read-only・副作用なし）。
+運用: 朝イチや作業ブランチ切替前、PR 作成前に `pnpm sync:check` を実行する。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "env:export": "op inject -i .env -o .env.local",
     "prepare": "lefthook install",
     "indexes:rebuild": "node .claude/skills/aiworkflow-requirements/scripts/generate-index.js",
+    "sync:check": "git fetch --quiet origin main dev 2>/dev/null; bash scripts/hooks/stale-worktree-notice.sh fetch",
     "skill:logs:render": "tsx scripts/skill-logs-render.ts",
     "skill:logs:append": "tsx scripts/skill-logs-append.ts"
   },

--- a/scripts/hooks/stale-worktree-notice.sh
+++ b/scripts/hooks/stale-worktree-notice.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
-# post-merge: 遅れている worktree を通知（read-only）
+# stale-worktree-notice: 遅れている worktree / ローカルブランチを通知（read-only）
 # 不変条件: このスクリプトは副作用を持たない（indexes 再生成は別コマンド）
-# 設計正本: docs/30-workflows/task-git-hooks-lefthook-and-post-merge/outputs/phase-2/design.md
+# 設計正本: docs/30-workflows/completed-tasks/task-git-hooks-lefthook-and-post-merge/outputs/phase-2/design.md
+#
+# 対応モード:
+#   post-merge   現在ブランチが main / dev のとき、その更新を他 worktree に通知
+#   fetch        origin/main / origin/dev とローカル main / dev の遅れを通知（手動 / `pnpm sync:check`）
+#
+# git には post-fetch hook が無いため、fetch モードは pnpm sync:check 経由で手動実行する。
 set -euo pipefail
 
 MODE="${1:-post-merge}"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# 監視対象の長期ブランチ（ローカルに存在するものだけを対象にする）
+TRACKED_BRANCHES=(main dev)
 
 list_stale_worktrees() {
   local target_ref="$1"
@@ -18,36 +27,96 @@ list_stale_worktrees() {
     echo "$line" | grep -q "prunable" && continue
     echo "$line" | grep -q "detached" && continue
     [ -z "$WT_BRANCH" ] && continue
-    [[ "$WT_BRANCH" =~ ^(main|master|develop|release/|hotfix/) ]] && continue
+    [[ "$WT_BRANCH" =~ ^(main|master|dev|develop|release/|hotfix/) ]] && continue
 
     BEHIND=$(git -C "$WT_PATH" rev-list --count "HEAD..${target_ref}" 2>/dev/null || echo "?")
     if [ "$BEHIND" != "0" ] && [ "$BEHIND" != "?" ]; then
-      printf "  📁 %s (%s) — %sコミット遅れ\n" "$(basename "$WT_PATH")" "$WT_BRANCH" "$BEHIND"
+      printf "  📁 %s (%s) — %sコミット遅れ (vs %s)\n" \
+        "$(basename "$WT_PATH")" "$WT_BRANCH" "$BEHIND" "$target_ref"
     fi
   done < <(git worktree list)
+}
+
+branch_exists_local() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+branch_exists_remote() {
+  git show-ref --verify --quiet "refs/remotes/origin/$1"
 }
 
 case "$MODE" in
   post-merge)
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
-    [ "$CURRENT_BRANCH" = "main" ] || exit 0
+    case "$CURRENT_BRANCH" in
+      main|dev) ;;
+      *) exit 0 ;;
+    esac
 
-    MAIN_HEAD=$(git log -1 --format="%h %s" main)
-    STALE=$(list_stale_worktrees main)
+    HEAD_INFO=$(git log -1 --format="%h %s" "$CURRENT_BRANCH")
+    STALE=$(list_stale_worktrees "$CURRENT_BRANCH")
     [ -z "$STALE" ] && exit 0
 
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "⚠️  [post-merge] mainが更新: ${MAIN_HEAD}"
-    echo "   以下のワークツリーでmain同期が必要です:"
+    echo "⚠️  [post-merge] ${CURRENT_BRANCH} が更新: ${HEAD_INFO}"
+    echo "   以下のワークツリーで ${CURRENT_BRANCH} 同期が必要です:"
     echo "$STALE"
     echo ""
     echo "   各ワークツリー内で実行:"
-    echo "   git fetch origin main && git merge origin/main --no-edit"
+    echo "   git fetch origin ${CURRENT_BRANCH} && git merge origin/${CURRENT_BRANCH} --no-edit"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     ;;
+
+  fetch)
+    # main / dev のローカルが origin より遅れていれば通知し、関連 worktree も列挙する。
+    # exit code は常に 0（read-only 通知）。
+    REPORTED=0
+    for BR in "${TRACKED_BRANCHES[@]}"; do
+      branch_exists_remote "$BR" || continue
+
+      if branch_exists_local "$BR"; then
+        AHEAD=$(git rev-list --count "${BR}..origin/${BR}" 2>/dev/null || echo "0")
+      else
+        AHEAD="?"
+      fi
+
+      STALE_WT=$(list_stale_worktrees "origin/${BR}")
+
+      if [ "$AHEAD" != "0" ] || [ -n "$STALE_WT" ]; then
+        if [ "$REPORTED" = "0" ]; then
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "🔄 [sync:check] リモート同期状況"
+          REPORTED=1
+        fi
+        REMOTE_HEAD=$(git log -1 --format="%h %s" "origin/${BR}" 2>/dev/null || echo "n/a")
+        if [ "$AHEAD" = "?" ]; then
+          echo "   • ローカル ${BR} が未作成 — 最新: ${REMOTE_HEAD}"
+          echo "       作成: git checkout -b ${BR} origin/${BR}"
+        elif [ "$AHEAD" != "0" ]; then
+          echo "   • ${BR}: origin が ${AHEAD} コミット先行 — 最新: ${REMOTE_HEAD}"
+          echo "       同期: git checkout ${BR} && git merge --ff-only origin/${BR}"
+        else
+          echo "   • ${BR}: ローカルは最新"
+        fi
+        if [ -n "$STALE_WT" ]; then
+          echo "     遅れているワークツリー:"
+          echo "$STALE_WT" | sed 's/^/    /'
+        fi
+      fi
+    done
+
+    if [ "$REPORTED" = "1" ]; then
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    else
+      echo "✅ [sync:check] main / dev ともリモートと同期済み・遅れている worktree はありません"
+    fi
+    ;;
+
   *)
     echo "[stale-worktree-notice] 未知のモード: $MODE" >&2
+    echo "  使用可能: post-merge | fetch" >&2
     exit 0
     ;;
 esac


### PR DESCRIPTION
## Summary

- `scripts/hooks/stale-worktree-notice.sh` に **`fetch` モード** を追加し、`origin/main` / `origin/dev` の先行コミット数と各 worktree の遅れを read-only で通知
- `post-merge` モードを `main` 単独から **`main` + `dev`** に拡張（dev ブランチ更新も他 worktree に通知）
- `pnpm sync:check` を新設し、手動チェックの正規経路として公開
- CLAUDE.md にリモート同期チェックの運用方針を明記

## 背景

- 直近の検証で「`git fetch` 後にリモート遅れを通知する仕組みが無い」という観察があった
- 調査の結果、**git に `post-fetch` フックは存在しない**（`task-git-hooks-lefthook-and-post-merge` phase-11 の P0-01 で旧 lefthook lane を削除済み）
- そのため自動 hook での解決は原理的に不可能 → **手動コマンドを正規経路化**するのがベストプラクティス

## 仕様

| モード | トリガ | 対象 |
|-------|--------|------|
| `pnpm sync:check`（`fetch`） | 手動 | `origin/main` / `origin/dev` の先行コミット、全 worktree の遅れ |
| `post-merge` フック | `git pull` / `git merge` 後、現在ブランチが `main` または `dev` のとき | 他 worktree の遅れ |

- read-only。副作用なし（indexes 再生成等は行わない）
- `pnpm sync:check` は `git fetch --quiet origin main dev` を内蔵し、`fetch + 通知` を1コマンドで完了

## 動作確認（ローカル）

- `pnpm sync:check` → `origin/main` / `origin/dev` 同期状況と全 worktree の遅れを正しく列挙（main 9件・dev 9件遅れを検出）
- `post-merge` モードを feature ブランチで実行 → 期待通り silent
- 不明モード呼び出し → 使用方法を表示して exit 0

## 品質検証

- [x] `pnpm typecheck`
- [x] `pnpm lint`（exit 0、既存 stablekey-literal warnings のみ）

## Test plan

- [ ] CI（typecheck / lint / verify-indexes / coverage-gate）が PASS
- [ ] マージ後、各 worktree で `pnpm sync:check` を実行して通知が見えることを確認
- [ ] 次回 `git pull origin dev` 時に post-merge 通知が dev ブランチでも発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)