### PR TITLE
chore: switch default integration branch to dev + fix CF token secret refs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -38,7 +38,7 @@ jobs:
         id: migrate
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CF_TOKEN_D1_STAGING }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.85.0
           workingDirectory: apps/api
@@ -49,7 +49,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CF_TOKEN_WORKERS_STAGING }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.85.0
           workingDirectory: apps/api
@@ -93,7 +93,7 @@ jobs:
         id: migrate
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CF_TOKEN_D1_PRODUCTION }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.85.0
           workingDirectory: apps/api
@@ -104,7 +104,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CF_TOKEN_WORKERS_PRODUCTION }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.85.0
           workingDirectory: apps/api

--- a/.github/workflows/web-cd.yml
+++ b/.github/workflows/web-cd.yml
@@ -41,7 +41,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CF_TOKEN_PAGES_STAGING }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.85.0
           workingDirectory: apps/web
@@ -78,7 +78,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CF_TOKEN_PAGES_PRODUCTION }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: 4.85.0
           workingDirectory: apps/web

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,8 @@ git には `post-fetch` hook が存在しないため、`git fetch` 後にリモ
 
 ### 目的と絶対原則
 
-- リモート `main` を基準にローカル `main` を同期し、作業ブランチへ取り込んでからPRを作成する。
+- **既定の PR base ブランチは `dev`**（開発統合ブランチ）。`main` への PR は production リリース時の `dev → main` のみ。
+- リモート `dev` を基準にローカル `dev` を同期し、作業ブランチへ取り込んでからPRを作成する。
 - 現在ブランチで上がっている変更は、ステージ済み・未ステージ・未追跡・コミット済み差分を問わず、すべてPRに含める。
 - ファイル種別、サイズ、自動生成物という理由で変更を除外しない。
 - PR本文は `.claude/commands/ai/diff-to-pr.md` をPhase 13仕様として扱い、該当する `outputs/phase-12/implementation-guide.md` の内容を漏れなく反映する。
@@ -207,9 +208,9 @@ git には `post-fetch` hook が存在しないため、`git fetch` 後にリモ
 
 ### 実行順序
 
-1. 現在ブランチと変更状況を確認する。`main` 直上またはブランチ未作成の場合は、差分の主題から `feat/`、`fix/`、`refactor/`、`docs/` のいずれかで作業ブランチを自律作成する。
-2. `git fetch origin main` を実行し、ローカル `main` を `origin/main` にfast-forward同期する。
-3. 作業ブランチに戻り、`main` をマージする。
+1. 現在ブランチと変更状況を確認する。`dev` 直上またはブランチ未作成の場合は、差分の主題から `feat/`、`fix/`、`refactor/`、`docs/` のいずれかで作業ブランチを自律作成する。
+2. `git fetch origin dev` を実行し、ローカル `dev` を `origin/dev` にfast-forward同期する。
+3. 作業ブランチに戻り、`dev` をマージする。
 4. コンフリクトがあれば以下の方針で自律解消し、`git add` と `git commit` まで行う。
 5. 品質検証は次の3コマンドだけを実行する。
    - `pnpm install --force`
@@ -217,18 +218,18 @@ git には `post-fetch` hook が存在しないため、`git fetch` 後にリモ
    - `pnpm lint`
 6. 品質検証が失敗した場合は最大3回まで自動修復し、修復差分をコミットする。
 7. `git status --porcelain` で未コミット変更を確認し、残っている変更は `git add -A` で全件含めてコミットする。
-8. `git diff main...HEAD --name-only` でPRに入るファイル一覧を取得し、PR本文作成時に漏れなし確認として扱う。
-9. `.claude/commands/ai/diff-to-pr.md` と `outputs/phase-12/implementation-guide.md` を参照してPR本文を作成し、通常PRとして作成する。
+8. `git diff dev...HEAD --name-only` でPRに入るファイル一覧を取得し、PR本文作成時に漏れなし確認として扱う。
+9. `.claude/commands/ai/diff-to-pr.md` と `outputs/phase-12/implementation-guide.md` を参照してPR本文を作成し、`gh pr create --base dev` で作成する（production リリース時のみ `--base main` を明示）。
 
 ### コンフリクト解消の既定方針
 
 | 種別 | 方針 |
 |------|------|
-| `package.json` / `tsconfig` などの設定ファイル | `main` 側を基準に採用し、作業ブランチ側の必要差分を再適用する |
+| `package.json` / `tsconfig` などの設定ファイル | `dev` 側を基準に採用し、作業ブランチ側の必要差分を再適用する |
 | `pnpm-lock.yaml` | 必要なら再生成し、`pnpm install --force` の結果を正とする |
 | ソースコード | 両側の変更意図を保持し、関数・import・型定義を統合する |
 | 自動生成物 | 生成元が明確な場合は再生成結果を正とする |
-| ドキュメント | `main` 側、作業ブランチ側の順に意味を結合し、重複行だけ除去する |
+| ドキュメント | `dev` 側、作業ブランチ側の順に意味を結合し、重複行だけ除去する |
 
 ### 品質検証失敗時の自動修復
 
@@ -240,7 +241,7 @@ git には `post-fetch` hook が存在しないため、`git fetch` 後にリモ
 ### PR作成前チェック
 
 - `git status --porcelain` が空であること。
-- `git diff main...HEAD --name-only` がPRに含めるファイル一覧として取得できていること。
+- `git diff dev...HEAD --name-only` がPRに含めるファイル一覧として取得できていること。
 - `implementation-guide.md` が存在する場合、その主要見出しと内容がPR本文に反映されていること。
 - `outputs/phase-11/` 配下の `png` / `jpg` / `jpeg` / `gif` / `webp` 画像数と、PR本文の画像参照が整合していること。
 - スクリーンショットがない場合、PR本文にスクリーンショット専用セクションを残さないこと。

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -14,11 +14,11 @@ echo "=== ワークツリー作成 ==="
 echo "ブランチ: $BRANCH"
 echo "パス    : $WT_PATH"
 
-# リモートmainを最新化
-git fetch origin main
+# リモートdevを最新化（dev = 開発統合ブランチ。main は production リリース時のみ）
+git fetch origin dev
 
-# ワークツリー作成（mainから分岐）
-git worktree add -b "$BRANCH" "$WT_PATH" origin/main
+# ワークツリー作成（devから分岐）
+git worktree add -b "$BRANCH" "$WT_PATH" origin/dev
 
 echo ""
 echo "=== pnpm install ==="

--- a/scripts/wt-health-check.sh
+++ b/scripts/wt-health-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# WT健全性チェック: マージ済みゾンビWT・origin/main遅れWTを検出して通知
+# WT健全性チェック: マージ済みゾンビWT・origin/dev遅れWTを検出して通知
 # 使い方: wt-health-check.sh [--silent]
 #   --silent: 問題がない場合は何も出力しない（PreToolUse hook用）
 
@@ -20,21 +20,21 @@ while IFS= read -r line; do
   # prunable/detachedはスキップ
   echo "$line" | grep -qE "prunable|detached" && continue
   [ -z "$WT_BRANCH" ] && continue
-  # mainブランチ系はスキップ
+  # 統合系ブランチはスキップ
   [[ "$WT_BRANCH" =~ ^(main|master|develop|dev|release/|hotfix/) ]] && continue
 
   WT_NAME=$(basename "$WT_PATH")
 
-  # origin/mainにマージ済みか確認（ゾンビWT検出）
-  if git branch -r --merged origin/main 2>/dev/null | grep -qF "origin/${WT_BRANCH}"; then
-    ZOMBIE_WTS="${ZOMBIE_WTS}\n  🧟 ${WT_NAME} [${WT_BRANCH}] → mainにマージ済み、削除推奨"
+  # origin/devにマージ済みか確認（ゾンビWT検出）
+  if git branch -r --merged origin/dev 2>/dev/null | grep -qF "origin/${WT_BRANCH}"; then
+    ZOMBIE_WTS="${ZOMBIE_WTS}\n  🧟 ${WT_NAME} [${WT_BRANCH}] → devにマージ済み、削除推奨"
     continue
   fi
 
-  # origin/mainより何コミット遅れているか
-  BEHIND=$(git -C "$WT_PATH" rev-list HEAD..origin/main --count 2>/dev/null || echo "?")
+  # origin/devより何コミット遅れているか
+  BEHIND=$(git -C "$WT_PATH" rev-list HEAD..origin/dev --count 2>/dev/null || echo "?")
   if [ "$BEHIND" != "0" ] && [ "$BEHIND" != "?" ] && [ "$BEHIND" -gt 0 ]; then
-    STALE_WTS="${STALE_WTS}\n  ⏰ ${WT_NAME} [${WT_BRANCH}] → origin/mainより${BEHIND}コミット遅れ"
+    STALE_WTS="${STALE_WTS}\n  ⏰ ${WT_NAME} [${WT_BRANCH}] → origin/devより${BEHIND}コミット遅れ"
   fi
 done < <(git worktree list)
 
@@ -50,7 +50,7 @@ echo "⚠️  [wt-health] ワークツリー健全性チェック"
 
 if [ -n "$ZOMBIE_WTS" ]; then
   echo ""
-  echo "  【ゾンビWT】ブランチがmainにマージ済みのワークツリー:"
+  echo "  【ゾンビWT】ブランチがdevにマージ済みのワークツリー:"
   printf "%b\n" "$ZOMBIE_WTS"
   echo ""
   echo "  削除コマンド例:"
@@ -60,11 +60,11 @@ fi
 
 if [ -n "$STALE_WTS" ]; then
   echo ""
-  echo "  【遅れWT】origin/mainに追従が必要なワークツリー:"
+  echo "  【遅れWT】origin/devに追従が必要なワークツリー:"
   printf "%b\n" "$STALE_WTS"
   echo ""
   echo "  同期コマンド例:"
-  echo "  git -C .worktrees/<name> merge origin/main --no-edit"
+  echo "  git -C .worktrees/<name> merge origin/dev --no-edit"
 fi
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

- **Default integration branch を `main` → `dev` に切り替え** (CLAUDE.md / `scripts/new-worktree.sh` / `scripts/wt-health-check.sh`)
- **`backend-ci` / `web-cd` ワークフローのシークレット名修正**: `CF_TOKEN_{D1,WORKERS,PAGES}_{STAGING,PRODUCTION}` (6本、未定義) → `CLOUDFLARE_API_TOKEN` (env-scoped、実在)。dev に main の内容が来て `deploy-staging` job が初発火 → secret 未定義で失敗していた問題を修正。

## 背景

dev が長期間 main から 348 コミット遅れていた状態を hard reset で同期した結果、これまで `if: github.ref_name == 'dev'` ゲートで発火していなかった `deploy-staging` job が初めて回り、ワークフロー側が参照するシークレット名と GitHub Environment 側の実体名が食い違う潜在不整合が表面化した。

セキュリティ的には per-resource トークン (D1/Workers/Pages 個別) が望ましいが、今回は **既存の単一 `CLOUDFLARE_API_TOKEN` で動かす方針** (ユーザー判断)。トークン分離は後追いで検討。

## Test plan

- [ ] `backend-ci` deploy-staging が緑になる
- [ ] `web-cd` deploy-staging が緑になる
- [ ] `ci` / `Validate Build` / `coverage-gate` 引き続きパス